### PR TITLE
feat(types): add shared design schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes that affect the public surfaces (HTTP API, `getdesign` npm package, `get
 
 ### Added
 
+- **[tools]** `@getdesign/tools` now ships concrete `crawler`, `extractors`, `render`, and `daytona` modules with deterministic URL/CSS resolution, token extraction, markdown rendering, and typed Daytona helpers.
+- **[infra]** `infra/daytona/Dockerfile` and `infra/daytona/README.md` define the first in-repo Daytona snapshot for Chromium + computer-use flows.
 - **[skill]** New fifth surface: portable `SKILL.md` at `skills/getdesign/` that reproduces the 9-section `design.md` contract using any coding agent's built-in tools (WebFetch, browser, file write). Installable via `npx skills add MohtashamMurshid/getdesign`.
 - **[skill]** `skills/getdesign/TEMPLATE.md` — field-by-field schema for each of the 9 sections, with example tables and a truncated worked example.
 - **[skill]** `skills/README.md` — overview, install commands, and link to the [skills.sh](https://skills.sh) leaderboard.

--- a/apps/web/.vercelignore
+++ b/apps/web/.vercelignore
@@ -1,0 +1,29 @@
+# Project-level .vercelignore takes precedence in Vercel monorepos.
+# Keep this scoped to files under apps/web only.
+
+# Local build artifacts and caches
+.next
+out
+coverage
+build
+
+# Local package installs
+node_modules
+
+# Logs and debug output
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Local environment files should not be uploaded from this project root
+.env*
+
+# Local Vercel metadata
+.vercel
+
+# OS / editor noise
+.DS_Store
+*.pem
+*.tsbuildinfo

--- a/bun.lock
+++ b/bun.lock
@@ -45,8 +45,11 @@
     "packages/sdk": {
       "name": "@getdesign/sdk",
       "version": "0.0.1",
+      "dependencies": {
+        "@getdesign/types": "workspace:*",
+      },
       "devDependencies": {
-        "typescript": "^5.6.0",
+        "typescript": "^6.0.3",
       },
     },
     "packages/tools": {
@@ -886,8 +889,6 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
-
-    "@getdesign/sdk/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
 

--- a/infra/daytona/Dockerfile
+++ b/infra/daytona/Dockerfile
@@ -1,4 +1,5 @@
-FROM daytonaio/workspace:latest
+# Pin a versioned Daytona sandbox base image so snapshot rebuilds stay reproducible.
+FROM daytonaio/sandbox:0.161.0
 
 USER root
 
@@ -18,6 +19,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Provide a deterministic Chromium entrypoint for the screenshot helpers.
+# /usr/local/bin/getdesign-chromium keeps --no-sandbox because typical
+# containerized Daytona runtimes rely on container isolation rather than the
+# Chromium sandbox, and often do not expose the user namespaces or seccomp /
+# AppArmor allowances Chromium needs. If your runtime enables those kernel
+# features, remove --no-sandbox from this wrapper.
 RUN printf '%s\n' \
   '#!/usr/bin/env bash' \
   'set -euo pipefail' \

--- a/infra/daytona/Dockerfile
+++ b/infra/daytona/Dockerfile
@@ -1,0 +1,31 @@
+FROM daytonaio/workspace:latest
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  chromium \
+  dbus-x11 \
+  fonts-dejavu-core \
+  fonts-liberation \
+  fonts-noto-color-emoji \
+  fonts-noto-core \
+  fonts-noto-mono \
+  fonts-noto-ui-core \
+  wmctrl \
+  x11-utils \
+  xdotool \
+  xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+# Provide a deterministic Chromium entrypoint for the screenshot helpers.
+RUN printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'exec chromium --no-sandbox --disable-dev-shm-usage "$@"' \
+  > /usr/local/bin/getdesign-chromium && chmod +x /usr/local/bin/getdesign-chromium
+
+USER daytona
+
+ENV DISPLAY=:1
+ENV GETDESIGN_VIEWPORT_WIDTH=1440
+ENV GETDESIGN_VIEWPORT_HEIGHT=900

--- a/infra/daytona/README.md
+++ b/infra/daytona/README.md
@@ -16,8 +16,7 @@ Build and publish from a machine that has the Daytona CLI configured:
 
 ```bash
 docker build -t getdesign-daytona-snapshot infra/daytona
-daytona snapshot create getdesign-local --image getdesign-daytona-snapshot
-daytona snapshot push getdesign-local getdesign-<sha>
+daytona snapshot push getdesign-daytona-snapshot --name getdesign-<sha>
 ```
 
 The runtime code in `packages/tools/src/daytona` expects the published snapshot

--- a/infra/daytona/README.md
+++ b/infra/daytona/README.md
@@ -1,0 +1,24 @@
+## Daytona snapshot
+
+This directory contains the baseline image definition for the `getdesign` visual
+capture sandbox.
+
+### What is included
+
+- Chromium for kiosk-style browsing
+- Xvfb + lightweight X11 utilities for deterministic display capture
+- fonts commonly needed by marketing sites (`Inter`, `Noto`, `Liberation`, `DejaVu`)
+- image tooling needed by the screenshot pipeline
+
+### Example workflow
+
+Build and publish from a machine that has the Daytona CLI configured:
+
+```bash
+docker build -t getdesign-daytona-snapshot infra/daytona
+daytona snapshot create getdesign-local --image getdesign-daytona-snapshot
+daytona snapshot push getdesign-local getdesign-<sha>
+```
+
+The runtime code in `packages/tools/src/daytona` expects the published snapshot
+name to be passed in explicitly, or derived from a `getdesign-<sha>` convention.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "typecheck": "turbo run typecheck",
-    "clean": "turbo run clean && rm -rf node_modules"
+    "clean": "turbo run clean && rm -rf node_modules",
+    "postinstall": "bun run --cwd ./packages/types build"
   },
   "packageManager": "bun@1.3.10",
   "engines": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,6 +48,9 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "@getdesign/types": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "^6.0.3"
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,19 +5,23 @@
  * Private beta. Join the waitlist at https://getdesign.app
  */
 
-export const version = "0.0.1";
+import type { DesignDoc, DesignTokens } from "@getdesign/types";
 
-export type DesignDoc = {
-  url: string;
-  markdown: string;
-  generatedAt: string;
-};
+export const version = "0.0.1";
+export type { DesignDoc, DesignTokens } from "@getdesign/types";
 
 export type GetDesignOptions = {
   /** Target viewport width for the screenshot pass. */
   viewport?: `${number}x${number}`;
   /** Optional API key (not required during preview). */
   apiKey?: string;
+};
+
+export type GetDesignResult = {
+  markdown: string;
+  doc: DesignDoc;
+  runId: string;
+  tokens?: DesignTokens;
 };
 
 /**
@@ -27,7 +31,7 @@ export type GetDesignOptions = {
 export async function getDesign(
   url: string,
   _options: GetDesignOptions = {},
-): Promise<DesignDoc> {
+): Promise<GetDesignResult> {
   throw new Error(
     `@getdesign/sdk is in private beta. Join the waitlist at https://getdesign.app (asked for: ${url})`,
   );

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,10 +5,10 @@
  * Private beta. Join the waitlist at https://getdesign.app
  */
 
-import type { DesignDoc, DesignTokens } from "@getdesign/types";
+import type { RenderedDesignResult } from "@getdesign/types";
 
 export const version = "0.0.1";
-export type { DesignDoc, DesignTokens } from "@getdesign/types";
+export type { DesignDoc, DesignTokens, RenderedDesignResult } from "@getdesign/types";
 
 export type GetDesignOptions = {
   /** Target viewport width for the screenshot pass. */
@@ -17,12 +17,7 @@ export type GetDesignOptions = {
   apiKey?: string;
 };
 
-export type GetDesignResult = {
-  markdown: string;
-  doc: DesignDoc;
-  runId: string;
-  tokens?: DesignTokens;
-};
+export type GetDesignResult = RenderedDesignResult;
 
 /**
  * Placeholder. The real implementation is in private beta.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -23,7 +23,8 @@
     "zod": "^4.3.6"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test"
   },
   "devDependencies": {
     "@getdesign/config": "workspace:*",

--- a/packages/tools/src/crawler/index.ts
+++ b/packages/tools/src/crawler/index.ts
@@ -1,0 +1,363 @@
+import { load } from "cheerio";
+import { z } from "zod";
+
+const nonEmptyStringSchema = z.string().trim().min(1);
+
+const crawlableUrlSchema = z.string().trim().url().superRefine((value, ctx) => {
+  const parsed = new URL(value);
+
+  if (parsed.protocol !== "https:") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Only HTTPS URLs are supported.",
+    });
+  }
+
+  if (isBlockedHostname(parsed.hostname)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Private, localhost, and link-local targets are not allowed.",
+    });
+  }
+});
+
+const crawledStylesheetSchema = z
+  .object({
+    kind: z.enum(["linked", "imported", "inline"]),
+    source: nonEmptyStringSchema,
+    content: z.string(),
+    url: z.string().url().optional(),
+    importedFrom: z.string().url().optional(),
+  })
+  .strict();
+
+const crawlSiteInputSchema = z
+  .object({
+    url: crawlableUrlSchema,
+    maxStylesheetBytes: z.number().int().positive().max(1_000_000).default(200_000),
+    maxImportDepth: z.number().int().min(0).max(3).default(1),
+  })
+  .strict();
+
+export const crawlSiteResultSchema = z
+  .object({
+    sourceUrl: z.string().url(),
+    siteName: nonEmptyStringSchema,
+    html: z.string(),
+    stylesheets: z.array(crawledStylesheetSchema),
+    sourceUrls: z.array(z.string().url()).min(1),
+    notes: z.array(nonEmptyStringSchema),
+  })
+  .strict();
+
+export type CrawledStylesheet = z.infer<typeof crawledStylesheetSchema>;
+export type StylesheetAsset = {
+  url: string;
+  css: string;
+  kind: CrawledStylesheet["kind"];
+  source: string;
+  importedFrom?: string;
+};
+export type CrawlSiteResult = z.infer<typeof crawlSiteResultSchema>;
+export type CrawlSiteInput = z.input<typeof crawlSiteInputSchema> & {
+  fetch?: typeof fetch;
+};
+
+export function validatePublicUrl(url: string): string {
+  return crawlableUrlSchema.parse(url);
+}
+
+export function extractStylesheetUrls(html: string, pageUrl: string): string[] {
+  const safeHtml = z.string().parse(html);
+  const baseUrl = crawlableUrlSchema.parse(pageUrl);
+  const $ = load(safeHtml);
+  const urls = new Set<string>();
+
+  $('link[rel~="stylesheet"]').each((_, element) => {
+    const href = $(element).attr("href");
+    const resolved = resolveCrawlableUrl(href, baseUrl);
+
+    if (resolved) {
+      urls.add(resolved);
+    }
+  });
+
+  return [...urls];
+}
+
+export function extractInlineStyles(html: string): string[] {
+  const safeHtml = z.string().parse(html);
+  const $ = load(safeHtml);
+  const styles: string[] = [];
+
+  $("style").each((_, element) => {
+    const content = $(element).html()?.trim();
+
+    if (content) {
+      styles.push(content);
+    }
+  });
+
+  return styles;
+}
+
+export function extractCssImportUrls(css: string, stylesheetUrl: string): string[] {
+  const safeCss = z.string().parse(css);
+  const baseUrl = crawlableUrlSchema.parse(stylesheetUrl);
+  const urls = new Set<string>();
+  const importPattern = /@import\s+(?:url\()?(?:"([^"]+)"|'([^']+)'|([^'")\s;]+))(?:\))?/gi;
+
+  for (const match of safeCss.matchAll(importPattern)) {
+    const rawUrl = match[1] ?? match[2] ?? match[3];
+    const resolved = resolveCrawlableUrl(rawUrl, baseUrl);
+
+    if (resolved) {
+      urls.add(resolved);
+    }
+  }
+
+  return [...urls];
+}
+
+export function deriveSiteName(html: string, pageUrl: string): string {
+  const safeHtml = z.string().parse(html);
+  const baseUrl = crawlableUrlSchema.parse(pageUrl);
+  const $ = load(safeHtml);
+  const candidates = [
+    $('meta[property="og:site_name"]').attr("content"),
+    $('meta[name="application-name"]').attr("content"),
+    $("title").first().text(),
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = candidate?.trim();
+
+    if (normalized) {
+      return normalized
+        .replace(/\s*[|·—-]\s*.*/u, "")
+        .trim();
+    }
+  }
+
+  return baseUrl.hostname.replace(/^www\./u, "");
+}
+
+export async function crawlSite(input: CrawlSiteInput): Promise<CrawlSiteResult> {
+  const { fetch: customFetch, ...serializable } = input;
+  const parsedInput = crawlSiteInputSchema.parse(serializable);
+  const fetcher = customFetch ?? globalThis.fetch;
+
+  if (typeof fetcher !== "function") {
+    throw new Error("A fetch implementation is required to crawl a URL.");
+  }
+
+  const html = await fetchText(fetcher, parsedInput.url);
+  const linkedStylesheets = extractStylesheetUrls(html, parsedInput.url);
+  const inlineStyles = extractInlineStyles(html);
+  const stylesheets: CrawledStylesheet[] = [];
+  const seenUrls = new Set<string>([parsedInput.url]);
+
+  for (const stylesheetUrl of linkedStylesheets) {
+    const content = trimStylesheet(await fetchText(fetcher, stylesheetUrl), parsedInput.maxStylesheetBytes);
+
+    stylesheets.push({
+      kind: "linked",
+      source: stylesheetUrl,
+      content,
+      url: stylesheetUrl,
+    });
+    seenUrls.add(stylesheetUrl);
+
+    const importedStylesheets = await fetchImportedStylesheets({
+      fetcher,
+      stylesheetUrl,
+      css: content,
+      maxBytes: parsedInput.maxStylesheetBytes,
+      maxDepth: parsedInput.maxImportDepth,
+      visited: seenUrls,
+    });
+
+    stylesheets.push(...importedStylesheets);
+  }
+
+  inlineStyles.forEach((content, index) => {
+    stylesheets.push({
+      kind: "inline",
+      source: `inline-style-${index + 1}`,
+      content: trimStylesheet(content, parsedInput.maxStylesheetBytes),
+    });
+  });
+
+  const notes = [
+    `Fetched ${linkedStylesheets.length} linked stylesheet${linkedStylesheets.length === 1 ? "" : "s"}.`,
+    `Captured ${inlineStyles.length} inline style block${inlineStyles.length === 1 ? "" : "s"}.`,
+  ];
+
+  if (stylesheets.length === 0) {
+    notes.push("No crawlable stylesheets were discovered in the HTML document.");
+  }
+
+  return crawlSiteResultSchema.parse({
+    sourceUrl: parsedInput.url,
+    siteName: deriveSiteName(html, parsedInput.url),
+    html,
+    stylesheets,
+    sourceUrls: [...seenUrls],
+    notes,
+  });
+}
+
+export function toStylesheetAssets(
+  result: CrawlSiteResult,
+): StylesheetAsset[] {
+  const parsed = crawlSiteResultSchema.parse(result);
+
+  return parsed.stylesheets
+    .filter((stylesheet): stylesheet is CrawledStylesheet & { url: string } =>
+      Boolean(stylesheet.url),
+    )
+    .map((stylesheet) => ({
+      url: stylesheet.url,
+      css: stylesheet.content,
+      kind: stylesheet.kind,
+      source: stylesheet.source,
+      importedFrom: stylesheet.importedFrom,
+    }));
+}
+
+async function fetchImportedStylesheets(input: {
+  fetcher: typeof fetch;
+  stylesheetUrl: string;
+  css: string;
+  maxBytes: number;
+  maxDepth: number;
+  visited: Set<string>;
+  depth?: number;
+}): Promise<CrawledStylesheet[]> {
+  const depth = input.depth ?? 0;
+
+  if (depth >= input.maxDepth) {
+    return [];
+  }
+
+  const importedUrls = extractCssImportUrls(input.css, input.stylesheetUrl);
+  const imported: CrawledStylesheet[] = [];
+
+  for (const importedUrl of importedUrls) {
+    if (input.visited.has(importedUrl)) {
+      continue;
+    }
+
+    input.visited.add(importedUrl);
+    const content = trimStylesheet(await fetchText(input.fetcher, importedUrl), input.maxBytes);
+
+    imported.push({
+      kind: "imported",
+      source: importedUrl,
+      content,
+      url: importedUrl,
+      importedFrom: input.stylesheetUrl,
+    });
+
+    const nested = await fetchImportedStylesheets({
+      ...input,
+      stylesheetUrl: importedUrl,
+      css: content,
+      depth: depth + 1,
+    });
+
+    imported.push(...nested);
+  }
+
+  return imported;
+}
+
+async function fetchText(fetcher: typeof fetch, url: string): Promise<string> {
+  const response = await fetcher(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+function trimStylesheet(content: string, maxBytes: number): string {
+  const buffer = Buffer.from(content, "utf8");
+
+  if (buffer.byteLength <= maxBytes) {
+    return content;
+  }
+
+  return buffer.subarray(0, maxBytes).toString("utf8");
+}
+
+function resolveCrawlableUrl(rawUrl: string | undefined, baseUrl: string): string | null {
+  if (!rawUrl) {
+    return null;
+  }
+
+  const trimmed = rawUrl.trim();
+
+  if (!trimmed || trimmed.startsWith("data:") || trimmed.startsWith("blob:")) {
+    return null;
+  }
+
+  let resolved: URL;
+
+  try {
+    resolved = new URL(trimmed, baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (resolved.protocol !== "https:" || isBlockedHostname(resolved.hostname)) {
+    return null;
+  }
+
+  return resolved.toString();
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+
+  if (
+    normalized === "localhost" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    normalized.endsWith(".local")
+  ) {
+    return true;
+  }
+
+  if (isPrivateIpv4(normalized)) {
+    return true;
+  }
+
+  return normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe80:");
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u.exec(hostname);
+
+  if (!match) {
+    return false;
+  }
+
+  const octets = match.slice(1).map(Number);
+
+  if (octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+
+  const [first, second] = octets;
+
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}

--- a/packages/tools/src/crawler/index.ts
+++ b/packages/tools/src/crawler/index.ts
@@ -121,7 +121,7 @@ export function extractCssImportUrls(css: string, stylesheetUrl: string): string
 
 export function deriveSiteName(html: string, pageUrl: string): string {
   const safeHtml = z.string().parse(html);
-  const baseUrl = crawlableUrlSchema.parse(pageUrl);
+  const baseUrl = new URL(crawlableUrlSchema.parse(pageUrl));
   const $ = load(safeHtml);
   const candidates = [
     $('meta[property="og:site_name"]').attr("content"),
@@ -351,7 +351,12 @@ function isPrivateIpv4(hostname: string): boolean {
     return false;
   }
 
-  const [first, second] = octets;
+  const first = octets[0];
+  const second = octets[1];
+
+  if (first === undefined || second === undefined) {
+    return false;
+  }
 
   return (
     first === 10 ||

--- a/packages/tools/src/crawler/index.ts
+++ b/packages/tools/src/crawler/index.ts
@@ -2,20 +2,23 @@ import { load } from "cheerio";
 import { z } from "zod";
 
 const nonEmptyStringSchema = z.string().trim().min(1);
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_REDIRECT_HOPS = 5;
+const DEFAULT_MAX_HTML_BYTES = 1_000_000;
 
 const crawlableUrlSchema = z.string().trim().url().superRefine((value, ctx) => {
   const parsed = new URL(value);
 
   if (parsed.protocol !== "https:") {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: "custom",
       message: "Only HTTPS URLs are supported.",
     });
   }
 
   if (isBlockedHostname(parsed.hostname)) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: "custom",
       message: "Private, localhost, and link-local targets are not allowed.",
     });
   }
@@ -133,9 +136,13 @@ export function deriveSiteName(html: string, pageUrl: string): string {
     const normalized = candidate?.trim();
 
     if (normalized) {
-      return normalized
+      const cleaned = normalized
         .replace(/\s*[|·—-]\s*.*/u, "")
         .trim();
+
+      if (cleaned) {
+        return cleaned;
+      }
     }
   }
 
@@ -151,14 +158,21 @@ export async function crawlSite(input: CrawlSiteInput): Promise<CrawlSiteResult>
     throw new Error("A fetch implementation is required to crawl a URL.");
   }
 
-  const html = await fetchText(fetcher, parsedInput.url);
+  const html = await fetchText(fetcher, parsedInput.url, {
+    maxBytes: DEFAULT_MAX_HTML_BYTES,
+  });
   const linkedStylesheets = extractStylesheetUrls(html, parsedInput.url);
   const inlineStyles = extractInlineStyles(html);
   const stylesheets: CrawledStylesheet[] = [];
   const seenUrls = new Set<string>([parsedInput.url]);
 
   for (const stylesheetUrl of linkedStylesheets) {
-    const content = trimStylesheet(await fetchText(fetcher, stylesheetUrl), parsedInput.maxStylesheetBytes);
+    const content = trimStylesheet(
+      await fetchText(fetcher, stylesheetUrl, {
+        maxBytes: parsedInput.maxStylesheetBytes,
+      }),
+      parsedInput.maxStylesheetBytes,
+    );
 
     stylesheets.push({
       kind: "linked",
@@ -249,7 +263,12 @@ async function fetchImportedStylesheets(input: {
     }
 
     input.visited.add(importedUrl);
-    const content = trimStylesheet(await fetchText(input.fetcher, importedUrl), input.maxBytes);
+    const content = trimStylesheet(
+      await fetchText(input.fetcher, importedUrl, {
+        maxBytes: input.maxBytes,
+      }),
+      input.maxBytes,
+    );
 
     imported.push({
       kind: "imported",
@@ -272,14 +291,102 @@ async function fetchImportedStylesheets(input: {
   return imported;
 }
 
-async function fetchText(fetcher: typeof fetch, url: string): Promise<string> {
-  const response = await fetcher(url);
+async function fetchText(
+  fetcher: typeof fetch,
+  url: string,
+  options: {
+    maxBytes: number;
+    timeoutMs?: number;
+    maxRedirectHops?: number;
+  },
+): Promise<string> {
+  let currentUrl = validatePublicUrl(url);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const maxRedirectHops = options.maxRedirectHops ?? DEFAULT_MAX_REDIRECT_HOPS;
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  for (let hop = 0; hop <= maxRedirectHops; hop += 1) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+
+    try {
+      response = await fetcher(currentUrl, {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`Timed out fetching ${currentUrl} after ${timeoutMs}ms.`);
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      const nextUrl = resolveCrawlableUrl(location ?? undefined, currentUrl);
+
+      if (!nextUrl) {
+        throw new Error(`Blocked redirect target while fetching ${currentUrl}.`);
+      }
+
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${currentUrl}: ${response.status} ${response.statusText}`);
+    }
+
+    return await readResponseText(response, currentUrl, options.maxBytes);
   }
 
-  return await response.text();
+  throw new Error(`Too many redirects while fetching ${url}.`);
+}
+
+async function readResponseText(
+  response: Response,
+  url: string,
+  maxBytes: number,
+): Promise<string> {
+  if (!response.body) {
+    const text = await response.text();
+
+    if (Buffer.byteLength(text, "utf8") > maxBytes) {
+      throw new Error(`Response from ${url} exceeded ${maxBytes} bytes.`);
+    }
+
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    if (!value) {
+      continue;
+    }
+
+    totalBytes += value.byteLength;
+
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      throw new Error(`Response from ${url} exceeded ${maxBytes} bytes.`);
+    }
+
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
 }
 
 function trimStylesheet(content: string, maxBytes: number): string {
@@ -359,7 +466,9 @@ function isPrivateIpv4(hostname: string): boolean {
   }
 
   return (
+    first === 0 ||
     first === 10 ||
+    (first === 100 && second >= 64 && second <= 127) ||
     first === 127 ||
     (first === 169 && second === 254) ||
     (first === 172 && second >= 16 && second <= 31) ||

--- a/packages/tools/src/daytona/index.ts
+++ b/packages/tools/src/daytona/index.ts
@@ -64,6 +64,10 @@ function assertNonEmptyText(value: string, label: string): void {
   }
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function normalizeScreenshotResponse(
   response: DaytonaScreenshotResponse,
 ): ScreenshotArtifact {
@@ -174,26 +178,47 @@ export async function daytonaScreenshotFullPage(
     throw new Error("Expected at least one full-page screenshot tile.");
   }
 
-  const metadata = await sharp(Buffer.from(firstTile.imageBase64, "base64"))
-    .metadata();
-  const width = metadata.width;
-  const tileHeight = metadata.height;
+  const preparedTiles = await Promise.all(
+    tiles.map(async (tile) => {
+      const buffer = Buffer.from(tile.imageBase64, "base64");
+      const metadata = await sharp(buffer).metadata();
 
-  if (!width || !tileHeight) {
-    throw new Error("Unable to determine screenshot tile dimensions.");
+      if (!metadata.width || !metadata.height) {
+        throw new Error("Unable to determine screenshot tile dimensions.");
+      }
+
+      return {
+        ...tile,
+        buffer,
+        width: metadata.width,
+        height: metadata.height,
+      };
+    }),
+  );
+
+  const width = firstTile.width ?? preparedTiles[0]?.width;
+  if (!width) {
+    throw new Error("Unable to determine screenshot tile width.");
   }
 
-  const totalHeight = Math.max(
-    ...tiles.map((tile) => tile.offsetY + tileHeight),
-  );
+  for (const tile of preparedTiles) {
+    if (tile.width !== width) {
+      throw new Error("Full-page screenshot tiles must all share the same width.");
+    }
+  }
 
-  const compositeInput = await Promise.all(
-    tiles.map(async (tile) => ({
-      input: Buffer.from(tile.imageBase64, "base64"),
-      top: tile.offsetY,
-      left: 0,
-    })),
+  const dedupedTiles = preparedTiles.filter((tile, index, allTiles) => (
+    index === 0 || tile.imageBase64 !== allTiles[index - 1]?.imageBase64
+  ));
+
+  const totalHeight = Math.max(
+    ...dedupedTiles.map((tile) => tile.offsetY + tile.height),
   );
+  const compositeInput = dedupedTiles.map((tile) => ({
+    input: tile.buffer,
+    top: tile.offsetY,
+    left: 0,
+  }));
 
   const stitched = await sharp({
     create: {
@@ -238,15 +263,19 @@ export function daytonaOpenUrlCommand(
   options: OpenUrlOptions = {},
 ): string {
   const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`);
+  }
+
   const chromiumBinary = options.chromiumBinary ?? "chromium";
   const display = options.display ?? ":1";
   const flags = [...DEFAULT_CHROMIUM_FLAGS, ...(options.extraFlags ?? [])];
-  const quotedUrl = JSON.stringify(parsed.toString());
+  const quotedUrl = shellSingleQuote(parsed.toString());
 
   return [
-    `DISPLAY=${display}`,
-    chromiumBinary,
-    ...flags,
+    `DISPLAY=${shellSingleQuote(display)}`,
+    shellSingleQuote(chromiumBinary),
+    ...flags.map(shellSingleQuote),
     quotedUrl,
   ].join(" ");
 }

--- a/packages/tools/src/daytona/index.ts
+++ b/packages/tools/src/daytona/index.ts
@@ -1,0 +1,252 @@
+import { Daytona, type CreateSandboxFromSnapshotParams, type Sandbox, type ScreenshotOptions } from "@daytonaio/sdk";
+import sharp from "sharp";
+
+const DEFAULT_SNAPSHOT_NAME = "getdesign-latest";
+const DEFAULT_TIMEOUT_SECONDS = 90;
+const DEFAULT_CHROMIUM_FLAGS = [
+  "--kiosk",
+  "--no-first-run",
+  "--hide-crash-restore-bubble",
+  "--disable-session-crashed-bubble",
+  "--no-default-browser-check",
+];
+
+export type DaytonaClientOptions = ConstructorParameters<typeof Daytona>[0];
+
+export type SpawnSandboxOptions = {
+  snapshot?: string;
+  timeoutSeconds?: number;
+  envVars?: Record<string, string>;
+  labels?: Record<string, string>;
+};
+
+export type OpenUrlOptions = {
+  timeoutSeconds?: number;
+  chromiumBinary?: string;
+  display?: string;
+  extraFlags?: string[];
+  env?: Record<string, string>;
+};
+
+export type ScreenshotArtifact = {
+  imageBase64: string;
+  width?: number;
+  height?: number;
+  format?: string;
+  sizeBytes?: number;
+};
+
+export type FullPageTile = ScreenshotArtifact & {
+  offsetY: number;
+};
+
+export type FullPageScreenshotOptions = {
+  capture: () => Promise<ScreenshotArtifact>;
+  scroll: (step: number) => Promise<void>;
+  steps: number;
+  scrollStepPx: number;
+};
+
+type DaytonaScreenshotResponse = {
+  image?: string;
+  imageBase64?: string;
+  data?: string;
+  width?: number;
+  height?: number;
+  format?: string;
+  size_bytes?: number;
+  sizeBytes?: number;
+};
+
+function assertNonEmptyText(value: string, label: string): void {
+  if (!value.trim()) {
+    throw new Error(`${label} must not be empty.`);
+  }
+}
+
+function normalizeScreenshotResponse(
+  response: DaytonaScreenshotResponse,
+): ScreenshotArtifact {
+  const imageBase64 =
+    response.imageBase64 ?? response.image ?? response.data;
+
+  if (!imageBase64) {
+    throw new Error("Daytona screenshot response did not contain image data.");
+  }
+
+  return {
+    imageBase64,
+    width: response.width,
+    height: response.height,
+    format: response.format,
+    sizeBytes: response.sizeBytes ?? response.size_bytes,
+  };
+}
+
+export function createDaytonaClient(
+  options?: DaytonaClientOptions,
+): Daytona {
+  return new Daytona(options);
+}
+
+export async function daytonaSpawn(
+  client: Daytona,
+  options: SpawnSandboxOptions = {},
+): Promise<Sandbox> {
+  const params: CreateSandboxFromSnapshotParams = {
+    snapshot: options.snapshot ?? DEFAULT_SNAPSHOT_NAME,
+    envVars: options.envVars,
+    labels: options.labels,
+  };
+
+  const sandbox = await client.create(params, {
+    timeout: options.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS,
+  });
+
+  await sandbox.computerUse.start();
+
+  return sandbox;
+}
+
+export async function daytonaOpenUrl(
+  sandbox: Sandbox,
+  url: string,
+  options: OpenUrlOptions = {},
+): Promise<void> {
+  const command = daytonaOpenUrlCommand(url, options);
+
+  const response = await sandbox.process.executeCommand(
+    command,
+    undefined,
+    options.env,
+    options.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS,
+  );
+
+  if (response.exitCode !== 0) {
+    throw new Error(
+      `Failed to open URL in Daytona sandbox: ${response.result.trim() || "unknown error"}`,
+    );
+  }
+}
+
+export async function daytonaScreenshotViewport(
+  sandbox: Sandbox,
+  options: ScreenshotOptions = {},
+): Promise<ScreenshotArtifact> {
+  const response = (await sandbox.computerUse.screenshot.takeCompressed({
+    format: options.format ?? "png",
+    quality: options.quality,
+    scale: options.scale,
+    showCursor: options.showCursor ?? false,
+  })) as DaytonaScreenshotResponse;
+
+  return normalizeScreenshotResponse(response);
+}
+
+export async function daytonaScreenshotFullPage(
+  options: FullPageScreenshotOptions,
+): Promise<ScreenshotArtifact> {
+  if (!Number.isInteger(options.steps) || options.steps <= 0) {
+    throw new Error("Full-page screenshot steps must be a positive integer.");
+  }
+
+  if (!Number.isFinite(options.scrollStepPx) || options.scrollStepPx <= 0) {
+    throw new Error("Full-page screenshot scrollStepPx must be greater than zero.");
+  }
+
+  const tiles: FullPageTile[] = [];
+
+  for (let index = 0; index < options.steps; index += 1) {
+    const tile = await options.capture();
+    tiles.push({
+      ...tile,
+      offsetY: index * options.scrollStepPx,
+    });
+
+    if (index < options.steps - 1) {
+      await options.scroll(options.scrollStepPx);
+    }
+  }
+
+  const firstTile = tiles[0];
+
+  if (!firstTile) {
+    throw new Error("Expected at least one full-page screenshot tile.");
+  }
+
+  const metadata = await sharp(Buffer.from(firstTile.imageBase64, "base64"))
+    .metadata();
+  const width = metadata.width;
+  const tileHeight = metadata.height;
+
+  if (!width || !tileHeight) {
+    throw new Error("Unable to determine screenshot tile dimensions.");
+  }
+
+  const totalHeight = Math.max(
+    ...tiles.map((tile) => tile.offsetY + tileHeight),
+  );
+
+  const compositeInput = await Promise.all(
+    tiles.map(async (tile) => ({
+      input: Buffer.from(tile.imageBase64, "base64"),
+      top: tile.offsetY,
+      left: 0,
+    })),
+  );
+
+  const stitched = await sharp({
+    create: {
+      width,
+      height: totalHeight,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite(compositeInput)
+    .png()
+    .toBuffer();
+
+  return {
+    imageBase64: stitched.toString("base64"),
+    width,
+    height: totalHeight,
+    format: "png",
+    sizeBytes: stitched.byteLength,
+  };
+}
+
+export async function daytonaStop(sandbox: Sandbox): Promise<void> {
+  await sandbox.delete();
+}
+
+export function getDefaultSnapshotName(): string {
+  return DEFAULT_SNAPSHOT_NAME;
+}
+
+export function designSnapshotName(commitSha: string): string {
+  assertNonEmptyText(commitSha, "commitSha");
+  return `getdesign-${commitSha.trim()}`;
+}
+
+export function buildSnapshotTag(commitSha: string): string {
+  return designSnapshotName(commitSha);
+}
+
+export function daytonaOpenUrlCommand(
+  url: string,
+  options: OpenUrlOptions = {},
+): string {
+  const parsed = new URL(url);
+  const chromiumBinary = options.chromiumBinary ?? "chromium";
+  const display = options.display ?? ":1";
+  const flags = [...DEFAULT_CHROMIUM_FLAGS, ...(options.extraFlags ?? [])];
+  const quotedUrl = JSON.stringify(parsed.toString());
+
+  return [
+    `DISPLAY=${display}`,
+    chromiumBinary,
+    ...flags,
+    quotedUrl,
+  ].join(" ");
+}

--- a/packages/tools/src/extractors/index.ts
+++ b/packages/tools/src/extractors/index.ts
@@ -1,0 +1,679 @@
+import { load } from "cheerio";
+import type { CheerioAPI } from "cheerio";
+import postcss, { type Declaration, type Root, type Rule } from "postcss";
+import safeParse from "postcss-safe-parser";
+
+import {
+  designTokensSchema,
+  type BorderToken,
+  type BreakpointToken,
+  type ColorToken,
+  type DesignTokens,
+  type FontFamilyToken,
+  type RadiusToken,
+  type ShadowToken,
+  type SpacingToken,
+  type TypeScaleToken,
+} from "@getdesign/types";
+
+import {
+  crawlSite,
+  crawlSiteResultSchema,
+  type CrawlSiteResult,
+  type CrawledStylesheet,
+} from "../crawler";
+
+const HEX_COLOR_PATTERN =
+  /#(?:[\dA-Fa-f]{3}|[\dA-Fa-f]{4}|[\dA-Fa-f]{6}|[\dA-Fa-f]{8})\b/g;
+const LENGTH_PATTERN =
+  /-?(?:\d*\.\d+|\d+)(?:px|rem|em|vw|vh|svh|svw|%)\b/g;
+const FONT_FAMILY_FALLBACK_PATTERN = /['"]/g;
+
+type WeightedValue = {
+  value: string;
+  count: number;
+  sources: Set<string>;
+};
+
+type WeightedMap = Map<string, WeightedValue>;
+
+type ExtractorContext = {
+  sourceUrl: string;
+  siteName: string;
+  html: string;
+  htmlDocument: CheerioAPI;
+  stylesheetAssets: CrawledStylesheet[];
+  root: Root;
+};
+
+type ExtractDesignTokensOptions = {
+  sourceUrl: string;
+  siteName?: string;
+  html?: string;
+  stylesheets?: CrawledStylesheet[];
+  crawlResult?: CrawlSiteResult;
+  fetch?: typeof fetch;
+};
+
+type CountedColor = ColorToken & { count: number };
+
+const CSS_SOURCE_LIMIT = 200_000;
+const FONT_ROLE_ORDER = ["display", "body", "mono", "ui", "accent"] as const;
+
+function createWeightedMap(): WeightedMap {
+  return new Map<string, WeightedValue>();
+}
+
+function incrementWeightedValue(
+  map: WeightedMap,
+  value: string,
+  source: string,
+  amount = 1,
+): void {
+  const current = map.get(value);
+  if (current) {
+    current.count += amount;
+    current.sources.add(source);
+    return;
+  }
+
+  map.set(value, {
+    value,
+    count: amount,
+    sources: new Set([source]),
+  });
+}
+
+function trimText(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function resolveSiteNameFromHtml(htmlDocument: CheerioAPI, sourceUrl: string): string {
+  const ogTitle = trimText(htmlDocument('meta[property="og:site_name"]').attr("content"));
+  if (ogTitle) {
+    return ogTitle;
+  }
+
+  const title = trimText(htmlDocument("title").text());
+  if (title) {
+    return title.split(/[\-|·|•|—]/)[0]?.trim() || title;
+  }
+
+  return new URL(sourceUrl).hostname.replace(/^www\./, "");
+}
+
+function normalizeStylesheetAssets(stylesheets: CrawledStylesheet[]): CrawledStylesheet[] {
+  return stylesheets.map((asset) => ({
+    ...asset,
+    content: asset.content.slice(0, CSS_SOURCE_LIMIT),
+  }));
+}
+
+function buildExtractorContext(input: {
+  sourceUrl: string;
+  siteName?: string;
+  html: string;
+  stylesheets: CrawledStylesheet[];
+}): ExtractorContext {
+  const htmlDocument = load(input.html);
+  const stylesheetAssets = normalizeStylesheetAssets(input.stylesheets);
+  const combinedCss = stylesheetAssets.map((asset) => asset.content).join("\n");
+  const root = safeParse(combinedCss) as Root;
+
+  return {
+    sourceUrl: input.sourceUrl,
+    siteName:
+      trimText(input.siteName) || resolveSiteNameFromHtml(htmlDocument, input.sourceUrl),
+    html: input.html,
+    htmlDocument,
+    stylesheetAssets,
+    root,
+  };
+}
+
+function declarationSource(decl: Declaration): string {
+  const parent = decl.parent;
+  if (parent?.type === "rule") {
+    return `${(parent as Rule).selector} { ${decl.prop}: ${decl.value} }`;
+  }
+
+  if (parent?.type === "atrule") {
+    return `@${parent.name} ${parent.params}`.trim();
+  }
+
+  return `${decl.prop}: ${decl.value}`;
+}
+
+function normalizeHexColor(value: string): string | null {
+  const match = value.match(/^#(?:[\dA-Fa-f]{3}|[\dA-Fa-f]{4}|[\dA-Fa-f]{6}|[\dA-Fa-f]{8})$/);
+  if (!match) {
+    return null;
+  }
+
+  return value.toUpperCase();
+}
+
+function classifyColor(prop: string, source: string): "primary" | "accent" | "neutral" | "surfaces" | "borders" | "semantic" {
+  const haystack = `${prop} ${source}`.toLowerCase();
+
+  if (/(success|positive)/.test(haystack)) {
+    return "semantic";
+  }
+
+  if (/(warning|caution)/.test(haystack)) {
+    return "semantic";
+  }
+
+  if (/(error|danger|destructive)/.test(haystack)) {
+    return "semantic";
+  }
+
+  if (/(info|notice|highlight)/.test(haystack)) {
+    return "semantic";
+  }
+
+  if (/(border|stroke|divider|outline)/.test(haystack)) {
+    return "borders";
+  }
+
+  if (/(background|surface|canvas|panel|card|overlay)/.test(haystack)) {
+    return "surfaces";
+  }
+
+  if (/(accent|brand|primary|cta|focus|link|interactive)/.test(haystack)) {
+    return "accent";
+  }
+
+  if (/(text|foreground|neutral|muted|gray|grey)/.test(haystack)) {
+    return "neutral";
+  }
+
+  return "primary";
+}
+
+function semanticRoleForSource(prop: string, source: string): "success" | "warning" | "error" | "info" | null {
+  const haystack = `${prop} ${source}`.toLowerCase();
+
+  if (/(success|positive)/.test(haystack)) {
+    return "success";
+  }
+
+  if (/(warning|caution)/.test(haystack)) {
+    return "warning";
+  }
+
+  if (/(error|danger|destructive)/.test(haystack)) {
+    return "error";
+  }
+
+  if (/(info|notice|highlight)/.test(haystack)) {
+    return "info";
+  }
+
+  return null;
+}
+
+function dedupeCountedColors(colors: CountedColor[]): ColorToken[] {
+  return colors
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+
+      return left.hex.localeCompare(right.hex);
+    })
+    .map(({ count: _count, ...color }) => color);
+}
+
+function extractColorsFromRoot(root: Root): DesignTokens["colors"] {
+  const bucketed = {
+    primary: new Map<string, CountedColor>(),
+    accent: new Map<string, CountedColor>(),
+    neutral: new Map<string, CountedColor>(),
+    surfaces: new Map<string, CountedColor>(),
+    borders: new Map<string, CountedColor>(),
+    semantic: {
+      success: new Map<string, CountedColor>(),
+      warning: new Map<string, CountedColor>(),
+      error: new Map<string, CountedColor>(),
+      info: new Map<string, CountedColor>(),
+    },
+  };
+
+  root.walkDecls((decl) => {
+    const source = declarationSource(decl);
+    const matches = decl.value.match(HEX_COLOR_PATTERN);
+    if (!matches) {
+      return;
+    }
+
+    for (const rawColor of matches) {
+      const hex = normalizeHexColor(rawColor);
+      if (!hex) {
+        continue;
+      }
+
+      const color: CountedColor = {
+        hex,
+        role: trimText(decl.prop.replace(/^--/, "").replace(/[-_]/g, " ")) || decl.prop,
+        source,
+        count: 1,
+      };
+
+      const semanticRole = semanticRoleForSource(decl.prop, source);
+      if (semanticRole) {
+        const existing = bucketed.semantic[semanticRole].get(hex);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          bucketed.semantic[semanticRole].set(hex, color);
+        }
+        continue;
+      }
+
+      const bucket = classifyColor(decl.prop, source);
+      const targetMap = bucketed[bucket];
+      const existing = targetMap.get(hex);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        targetMap.set(hex, color);
+      }
+    }
+  });
+
+  return {
+    primary: dedupeCountedColors([...bucketed.primary.values()]).slice(0, 8),
+    accent: dedupeCountedColors([...bucketed.accent.values()]).slice(0, 8),
+    neutral: dedupeCountedColors([...bucketed.neutral.values()]).slice(0, 8),
+    semantic: {
+      success: dedupeCountedColors([...bucketed.semantic.success.values()]).slice(0, 4),
+      warning: dedupeCountedColors([...bucketed.semantic.warning.values()]).slice(0, 4),
+      error: dedupeCountedColors([...bucketed.semantic.error.values()]).slice(0, 4),
+      info: dedupeCountedColors([...bucketed.semantic.info.values()]).slice(0, 4),
+    },
+    surfaces: dedupeCountedColors([...bucketed.surfaces.values()]).slice(0, 8),
+    borders: dedupeCountedColors([...bucketed.borders.values()]).slice(0, 8),
+  };
+}
+
+function dedupeTokenValues<T extends { source: string }>(
+  values: T[],
+  getKey: (value: T) => string,
+): T[] {
+  const map = new Map<string, T>();
+
+  for (const value of values) {
+    const key = getKey(value);
+    if (!map.has(key)) {
+      map.set(key, value);
+    }
+  }
+
+  return [...map.values()];
+}
+
+function extractFontFamilies(root: Root): FontFamilyToken[] {
+  const fontMap = new Map<string, FontFamilyToken>();
+
+  root.walkAtRules("font-face", (rule) => {
+    let family = "";
+    const weights: string[] = [];
+
+    rule.walkDecls((decl) => {
+      if (decl.prop === "font-family") {
+        family = trimText(decl.value.replace(FONT_FAMILY_FALLBACK_PATTERN, ""));
+      }
+
+      if (decl.prop === "font-weight") {
+        weights.push(trimText(decl.value));
+      }
+    });
+
+    if (!family) {
+      return;
+    }
+
+    const lowerFamily = family.toLowerCase();
+    const role: FontFamilyToken["role"] =
+      lowerFamily.includes("mono") || lowerFamily.includes("code")
+        ? "mono"
+        : lowerFamily.includes("display")
+          ? "display"
+          : "body";
+
+    fontMap.set(family, {
+      family,
+      role,
+      source: "@font-face",
+      weights,
+    });
+  });
+
+  root.walkDecls((decl) => {
+    if (decl.prop !== "font-family") {
+      return;
+    }
+
+    const source = declarationSource(decl);
+    const families = decl.value
+      .split(",")
+      .map((value) => trimText(value.replace(FONT_FAMILY_FALLBACK_PATTERN, "")))
+      .filter(Boolean);
+
+    for (const family of families) {
+      if (fontMap.has(family)) {
+        continue;
+      }
+
+      const lowerSource = source.toLowerCase();
+      const role: FontFamilyToken["role"] =
+        lowerSource.includes("code") || lowerSource.includes("mono")
+          ? "mono"
+          : lowerSource.includes("hero") ||
+              lowerSource.includes("display") ||
+              lowerSource.includes("h1")
+            ? "display"
+            : "body";
+
+      fontMap.set(family, {
+        family,
+        role,
+        source,
+        weights: [],
+      });
+    }
+  });
+
+  return [...fontMap.values()].sort((left, right) => {
+    const leftIndex = FONT_ROLE_ORDER.indexOf(left.role);
+    const rightIndex = FONT_ROLE_ORDER.indexOf(right.role);
+    return leftIndex - rightIndex || left.family.localeCompare(right.family);
+  });
+}
+
+function inferTypeRole(rule: Rule, decl: Declaration): string {
+  const selector = rule.selector.toLowerCase();
+  if (selector.includes("h1")) return "H1";
+  if (selector.includes("h2")) return "H2";
+  if (selector.includes("h3")) return "H3";
+  if (selector.includes("small")) return "Small";
+  if (selector.includes("code") || selector.includes("mono")) return "Mono";
+  if (selector.includes("hero") || selector.includes("display")) return "Display";
+
+  const sizeMatch = decl.value.match(/(\d+(?:\.\d+)?)px/);
+  if (!sizeMatch) return "Body";
+
+  const size = Number(sizeMatch[1]);
+  if (size >= 48) return "Display";
+  if (size >= 36) return "H1";
+  if (size >= 28) return "H2";
+  if (size >= 20) return "H3";
+  if (size <= 14) return "Small";
+  return "Body";
+}
+
+function extractTypographyScale(root: Root): TypeScaleToken[] {
+  const tokens: TypeScaleToken[] = [];
+  const seen = new Set<string>();
+  const ruleState = new WeakMap<Rule, Partial<TypeScaleToken>>();
+
+  root.walkRules((rule) => {
+    ruleState.set(rule, {});
+  });
+
+  root.walkDecls((decl) => {
+    const parent = decl.parent;
+    if (parent?.type !== "rule") {
+      return;
+    }
+
+    const rule = parent as Rule;
+    const current = ruleState.get(rule) ?? {};
+    if (decl.prop === "font-family") {
+      current.source = declarationSource(decl);
+    }
+    if (decl.prop === "font-size") {
+      current.size = trimText(decl.value);
+      current.role = inferTypeRole(rule, decl);
+      current.source = declarationSource(decl);
+    }
+    if (decl.prop === "font-weight") {
+      current.weight = trimText(decl.value);
+    }
+    if (decl.prop === "line-height") {
+      current.lineHeight = trimText(decl.value);
+    }
+    if (decl.prop === "letter-spacing") {
+      current.letterSpacing = trimText(decl.value);
+    }
+    if (decl.prop === "font-family") {
+      current.weight ??= "400";
+      current.lineHeight ??= "normal";
+      current.letterSpacing ??= "normal";
+      current.source ??= declarationSource(decl);
+      current.role ??= inferTypeRole(rule, decl);
+      current.size ??= "16px";
+    }
+
+    const candidate = current as Partial<TypeScaleToken>;
+    if (!candidate.role || !candidate.size || !candidate.source) {
+      ruleState.set(rule, current);
+      return;
+    }
+
+    const entry: TypeScaleToken = {
+      role: candidate.role,
+      size: candidate.size,
+      weight: candidate.weight ?? "400",
+      lineHeight: candidate.lineHeight ?? "normal",
+      letterSpacing: candidate.letterSpacing ?? "normal",
+      source: candidate.source,
+    };
+
+    const key = `${entry.role}|${entry.size}|${entry.weight}|${entry.lineHeight}|${entry.letterSpacing}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      tokens.push(entry);
+    }
+
+    ruleState.set(rule, current);
+  });
+
+  return tokens.slice(0, 12);
+}
+
+function extractSpacing(root: Root): SpacingToken[] {
+  const spacing = createWeightedMap();
+
+  root.walkDecls((decl) => {
+    const matches = decl.value.match(LENGTH_PATTERN);
+    if (!matches) {
+      return;
+    }
+
+    if (!/(margin|padding|gap|inset|space|top|right|bottom|left|width|height)/i.test(decl.prop)) {
+      return;
+    }
+
+    const source = declarationSource(decl);
+    for (const match of matches) {
+      incrementWeightedValue(spacing, match, source);
+    }
+  });
+
+  return [...spacing.values()]
+    .filter((value) => value.count >= 2)
+    .sort((left, right) => left.count - right.count || left.value.localeCompare(right.value))
+    .map(
+      (value): SpacingToken => ({
+        value: value.value,
+        source: [...value.sources][0] ?? value.value,
+        usageCount: value.count,
+      }),
+    );
+}
+
+function extractRadii(root: Root): RadiusToken[] {
+  const radii: RadiusToken[] = [];
+
+  root.walkDecls((decl) => {
+    if (!/border-radius|radius/i.test(decl.prop)) {
+      return;
+    }
+
+    radii.push({
+      name:
+        decl.prop.startsWith("--")
+          ? trimText(decl.prop.replace(/^--/, "").replace(/[-_]/g, " "))
+          : decl.prop,
+      value: trimText(decl.value),
+      source: declarationSource(decl),
+    });
+  });
+
+  return dedupeTokenValues(radii, (radius) => `${radius.name}|${radius.value}`);
+}
+
+function extractShadows(root: Root): ShadowToken[] {
+  const shadows: ShadowToken[] = [];
+
+  root.walkDecls((decl) => {
+    if (!/box-shadow|shadow/i.test(decl.prop)) {
+      return;
+    }
+
+    shadows.push({
+      value: trimText(decl.value),
+      role: trimText(decl.prop.replace(/^--/, "").replace(/[-_]/g, " ")),
+      source: declarationSource(decl),
+    });
+  });
+
+  return dedupeTokenValues(shadows, (shadow) => `${shadow.role}|${shadow.value}`);
+}
+
+function extractBorders(root: Root): BorderToken[] {
+  const borders: BorderToken[] = [];
+
+  root.walkDecls((decl) => {
+    const source = declarationSource(decl);
+
+    if (decl.prop === "border") {
+      const width = decl.value.match(/(?:\d*\.\d+|\d+)px/)?.[0];
+      const style = decl.value.match(/\b(solid|dashed|dotted|double|none)\b/i)?.[0];
+      const color = decl.value.match(HEX_COLOR_PATTERN)?.[0];
+
+      if (!width || !color) {
+        return;
+      }
+
+      borders.push({
+        width,
+        style: style ? style.toLowerCase() : "solid",
+        color: color.toUpperCase(),
+        role: "border",
+        source,
+      });
+      return;
+    }
+
+    if (decl.prop === "border-width") {
+      borders.push({
+        width: trimText(decl.value),
+        style: "solid",
+        color: "#000000",
+        role: "border width placeholder",
+        source,
+      });
+      return;
+    }
+  });
+
+  return dedupeTokenValues(
+    borders.filter((border) => border.color !== "#000000" || border.width !== "0"),
+    (border) => `${border.width}|${border.style ?? ""}|${border.color}`,
+  );
+}
+
+function extractBreakpoints(root: Root): BreakpointToken[] {
+  const breakpoints: BreakpointToken[] = [];
+
+  root.walkAtRules("media", (rule) => {
+    const match = rule.params.match(/min-width:\s*([^)]+)/i);
+    if (!match) {
+      return;
+    }
+
+    breakpoints.push({
+      name: `bp-${breakpoints.length + 1}`,
+      minWidth: trimText(match[1]),
+      source: `@media ${rule.params}`,
+    });
+  });
+
+  return dedupeTokenValues(breakpoints, (breakpoint) => breakpoint.minWidth);
+}
+
+export function extractDesignTokens(
+  options: ExtractDesignTokensOptions,
+): DesignTokens {
+  const sourceUrl = options.sourceUrl.trim();
+  if (!sourceUrl) {
+    throw new Error("extractDesignTokens requires a sourceUrl.");
+  }
+
+  const crawlResult = options.crawlResult
+    ? crawlSiteResultSchema.parse(options.crawlResult)
+    : null;
+  const html = options.html ?? crawlResult?.html;
+  const stylesheets = options.stylesheets ?? crawlResult?.stylesheets;
+
+  if (!html) {
+    throw new Error("extractDesignTokens requires html or crawlResult.html.");
+  }
+
+  if (!stylesheets || stylesheets.length === 0) {
+    throw new Error(
+      "extractDesignTokens requires at least one stylesheet or a crawlResult with stylesheets.",
+    );
+  }
+
+  const context = buildExtractorContext({
+    sourceUrl,
+    siteName: options.siteName ?? crawlResult?.siteName,
+    html,
+    stylesheets,
+  });
+
+  return designTokensSchema.parse({
+    siteName: context.siteName,
+    sourceUrl,
+    sources: context.stylesheetAssets.map((asset) => asset.url),
+    colors: extractColorsFromRoot(context.root),
+    typography: {
+      fontFamilies: extractFontFamilies(context.root),
+      scale: extractTypographyScale(context.root),
+    },
+    spacing: extractSpacing(context.root),
+    radii: extractRadii(context.root),
+    shadows: extractShadows(context.root),
+    borders: extractBorders(context.root),
+    breakpoints: extractBreakpoints(context.root),
+  });
+}
+
+export async function extractDesignTokensFromUrl(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DesignTokens> {
+  const crawlResult = await crawlSite({
+    url,
+    fetch: fetchImpl,
+  });
+  return extractDesignTokens({
+    sourceUrl: crawlResult.sourceUrl,
+    siteName: crawlResult.siteName,
+    crawlResult,
+  });
+}

--- a/packages/tools/src/extractors/index.ts
+++ b/packages/tools/src/extractors/index.ts
@@ -115,6 +115,10 @@ function normalizeStylesheetAssets(stylesheets: CrawledStylesheet[]): CrawledSty
   }));
 }
 
+function stylesheetSourceUrl(asset: CrawledStylesheet, sourceUrl: string): string {
+  return asset.url ?? sourceUrl;
+}
+
 function buildExtractorContext(input: {
   sourceUrl: string;
   siteName?: string;
@@ -360,11 +364,14 @@ function extractFontFamilies(root: Root): FontFamilyToken[] {
           ? "display"
           : "body";
 
+    const existing = fontMap.get(family);
+    const mergedWeights = [...new Set([...(existing?.weights ?? []), ...weights])];
+
     fontMap.set(family, {
       family,
-      role,
-      source: "@font-face",
-      weights,
+      role: existing?.role ?? role,
+      source: existing?.source ?? "@font-face",
+      weights: mergedWeights,
     });
   });
 
@@ -434,59 +441,46 @@ function inferTypeRole(rule: Rule, decl: Declaration): string {
 function extractTypographyScale(root: Root): TypeScaleToken[] {
   const tokens: TypeScaleToken[] = [];
   const seen = new Set<string>();
-  const ruleState = new WeakMap<Rule, Partial<TypeScaleToken>>();
 
   root.walkRules((rule) => {
-    ruleState.set(rule, {});
-  });
+    const current: Partial<TypeScaleToken> = {};
 
-  root.walkDecls((decl) => {
-    const parent = decl.parent;
-    if (parent?.type !== "rule") {
-      return;
-    }
+    rule.walkDecls((decl) => {
+      if (decl.prop === "font-family") {
+        current.weight ??= "400";
+        current.lineHeight ??= "normal";
+        current.letterSpacing ??= "normal";
+        current.source ??= declarationSource(decl);
+        current.role ??= inferTypeRole(rule, decl);
+        current.size ??= "16px";
+      }
+      if (decl.prop === "font-size") {
+        current.size = trimText(decl.value);
+        current.role = inferTypeRole(rule, decl);
+        current.source = declarationSource(decl);
+      }
+      if (decl.prop === "font-weight") {
+        current.weight = trimText(decl.value);
+      }
+      if (decl.prop === "line-height") {
+        current.lineHeight = trimText(decl.value);
+      }
+      if (decl.prop === "letter-spacing") {
+        current.letterSpacing = trimText(decl.value);
+      }
+    });
 
-    const rule = parent as Rule;
-    const current = ruleState.get(rule) ?? {};
-    if (decl.prop === "font-family") {
-      current.source = declarationSource(decl);
-    }
-    if (decl.prop === "font-size") {
-      current.size = trimText(decl.value);
-      current.role = inferTypeRole(rule, decl);
-      current.source = declarationSource(decl);
-    }
-    if (decl.prop === "font-weight") {
-      current.weight = trimText(decl.value);
-    }
-    if (decl.prop === "line-height") {
-      current.lineHeight = trimText(decl.value);
-    }
-    if (decl.prop === "letter-spacing") {
-      current.letterSpacing = trimText(decl.value);
-    }
-    if (decl.prop === "font-family") {
-      current.weight ??= "400";
-      current.lineHeight ??= "normal";
-      current.letterSpacing ??= "normal";
-      current.source ??= declarationSource(decl);
-      current.role ??= inferTypeRole(rule, decl);
-      current.size ??= "16px";
-    }
-
-    const candidate = current as Partial<TypeScaleToken>;
-    if (!candidate.role || !candidate.size || !candidate.source) {
-      ruleState.set(rule, current);
+    if (!current.role || !current.size || !current.source) {
       return;
     }
 
     const entry: TypeScaleToken = {
-      role: candidate.role,
-      size: candidate.size,
-      weight: candidate.weight ?? "400",
-      lineHeight: candidate.lineHeight ?? "normal",
-      letterSpacing: candidate.letterSpacing ?? "normal",
-      source: candidate.source,
+      role: current.role,
+      size: current.size,
+      weight: current.weight ?? "400",
+      lineHeight: current.lineHeight ?? "normal",
+      letterSpacing: current.letterSpacing ?? "normal",
+      source: current.source,
     };
 
     const key = `${entry.role}|${entry.size}|${entry.weight}|${entry.lineHeight}|${entry.letterSpacing}`;
@@ -494,8 +488,6 @@ function extractTypographyScale(root: Root): TypeScaleToken[] {
       seen.add(key);
       tokens.push(entry);
     }
-
-    ruleState.set(rule, current);
   });
 
   return tokens.slice(0, 12);
@@ -597,19 +589,12 @@ function extractBorders(root: Root): BorderToken[] {
     }
 
     if (decl.prop === "border-width") {
-      borders.push({
-        width: trimText(decl.value),
-        style: "solid",
-        color: "#000000",
-        role: "border width placeholder",
-        source,
-      });
       return;
     }
   });
 
   return dedupeTokenValues(
-    borders.filter((border) => border.color !== "#000000" || border.width !== "0"),
+    borders,
     (border) => `${border.width}|${border.style ?? ""}|${border.color}`,
   );
 }
@@ -667,7 +652,11 @@ export function extractDesignTokens(
   return designTokensSchema.parse({
     siteName: context.siteName,
     sourceUrl,
-    sources: context.stylesheetAssets.map((asset) => asset.url),
+    sources: [
+      ...new Set(
+        context.stylesheetAssets.map((asset) => stylesheetSourceUrl(asset, sourceUrl)),
+      ),
+    ],
     colors: extractColorsFromRoot(context.root),
     typography: {
       fontFamilies: extractFontFamilies(context.root),

--- a/packages/tools/src/extractors/index.ts
+++ b/packages/tools/src/extractors/index.ts
@@ -59,6 +59,12 @@ type CountedColor = ColorToken & { count: number };
 
 const CSS_SOURCE_LIMIT = 200_000;
 const FONT_ROLE_ORDER = ["display", "body", "mono", "ui", "accent"] as const;
+type NonSemanticColorBucket =
+  | "primary"
+  | "accent"
+  | "neutral"
+  | "surfaces"
+  | "borders";
 
 function createWeightedMap(): WeightedMap {
   return new Map<string, WeightedValue>();
@@ -213,6 +219,15 @@ function semanticRoleForSource(prop: string, source: string): "success" | "warni
   return null;
 }
 
+function classifyNonSemanticColor(
+  prop: string,
+  source: string,
+): NonSemanticColorBucket {
+  const bucket = classifyColor(prop, source);
+
+  return bucket === "semantic" ? "primary" : bucket;
+}
+
 function dedupeCountedColors(colors: CountedColor[]): ColorToken[] {
   return colors
     .sort((left, right) => {
@@ -271,7 +286,10 @@ function extractColorsFromRoot(root: Root): DesignTokens["colors"] {
         continue;
       }
 
-      const bucket = classifyColor(decl.prop, source);
+      const bucket = classifyNonSemanticColor(
+        decl.prop,
+        source,
+      );
       const targetMap = bucketed[bucket];
       const existing = targetMap.get(hex);
       if (existing) {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,3 +1,4 @@
-// @getdesign/tools - Pure functions exposed as AI SDK tools.
-// See architecture.md §4 (Agent topology) for the tool surface.
-export {};
+export * from "./crawler";
+export * from "./daytona";
+export * from "./extractors";
+export * from "./render";

--- a/packages/tools/src/postcss-safe-parser.d.ts
+++ b/packages/tools/src/postcss-safe-parser.d.ts
@@ -1,0 +1,8 @@
+declare module "postcss-safe-parser" {
+  import type { Root } from "postcss";
+
+  export default function safeParse(
+    css: string,
+    opts?: Record<string, unknown>,
+  ): Root;
+}

--- a/packages/tools/src/postcss-safe-parser.d.ts
+++ b/packages/tools/src/postcss-safe-parser.d.ts
@@ -1,8 +1,8 @@
 declare module "postcss-safe-parser" {
-  import type { Root } from "postcss";
+  import type { ProcessOptions, Root } from "postcss";
 
   export default function safeParse(
     css: string,
-    opts?: Record<string, unknown>,
+    opts?: ProcessOptions,
   ): Root;
 }

--- a/packages/tools/src/render/index.ts
+++ b/packages/tools/src/render/index.ts
@@ -1,0 +1,173 @@
+import {
+  designDocSchema,
+  type ButtonStyle,
+  type ColorPaletteGroup,
+  type DesignDoc,
+  type TypographyHierarchyEntry,
+} from "@getdesign/types";
+
+const EOL = "\n";
+
+function joinLines(lines: string[]): string {
+  return `${lines.join(EOL).trimEnd()}${EOL}`;
+}
+
+function renderColorGroup(group: ColorPaletteGroup): string[] {
+  return [
+    `### ${group.heading}`,
+    "| Hex | Role | Where seen |",
+    "| --- | --- | --- |",
+    ...group.entries.map(
+      (entry) =>
+        `| \`${entry.hex}\` | ${entry.role} | ${entry.whereSeen} |`,
+    ),
+    "",
+  ];
+}
+
+function renderTypographyRow(entry: TypographyHierarchyEntry): string {
+  return `| ${entry.role} | ${entry.font} | ${entry.size} | ${entry.weight} | ${entry.lineHeight} | ${entry.letterSpacing} |`;
+}
+
+function renderButton(button: ButtonStyle): string[] {
+  return [
+    `- **${button.variant}** — background: ${button.background}; text: ${button.textColor}; border: ${button.border}; radius: ${button.radius}; padding: ${button.padding}; hover: ${button.hoverShift}`,
+  ];
+}
+
+function renderBullets(items: string[]): string[] {
+  return items.map((item) => `- ${item}`);
+}
+
+export function renderDesignMd(input: DesignDoc): string {
+  const doc = designDocSchema.parse(input);
+
+  const lines: string[] = [
+    `# ${doc.siteName} Design System`,
+    "",
+    "## 1. Visual Theme & Atmosphere",
+    "",
+    ...doc.visualTheme.overview,
+    "",
+    "### Key Characteristics",
+    ...renderBullets(doc.visualTheme.keyCharacteristics),
+    "",
+    "## 2. Color Palette & Roles",
+    "",
+    doc.palette.philosophy,
+    "",
+    ...doc.palette.groups.flatMap(renderColorGroup),
+    "### Notes",
+    doc.palette.notes,
+    "",
+    "## 3. Typography Rules",
+    "",
+    doc.typography.summary,
+    "",
+    "### Hierarchy",
+    "| Role | Font | Size | Weight | Line height | Letter spacing |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...doc.typography.hierarchy.map(renderTypographyRow),
+    "",
+    "### Principles",
+    ...renderBullets(doc.typography.principles),
+    "",
+    "## 4. Component Stylings",
+    "",
+    "### Buttons",
+    ...doc.components.buttons.flatMap(renderButton),
+    "",
+    "### Cards",
+    doc.components.cards.description,
+    ...renderBullets(doc.components.cards.tokens),
+    "",
+    "### Inputs",
+    doc.components.inputs.description,
+    ...renderBullets(doc.components.inputs.tokens),
+    "",
+    "### Navigation",
+    doc.components.navigation.description,
+    ...renderBullets(doc.components.navigation.tokens),
+    "",
+    "### Image Treatment",
+    doc.components.imageTreatment.description,
+    ...renderBullets(doc.components.imageTreatment.tokens),
+    "",
+    "### Distinctive",
+    ...doc.components.distinctive.flatMap((component) => [
+      `- **${component.name}** — ${component.description}`,
+    ]),
+    "",
+    "## 5. Layout Principles",
+    "",
+    "### Spacing Scale",
+    doc.layout.spacingScale,
+    "",
+    "### Grid",
+    doc.layout.grid,
+    "",
+    "### Whitespace",
+    doc.layout.whitespace,
+    "",
+    "### Radius Scale",
+    doc.layout.radiusScale,
+    "",
+    "## 6. Depth & Elevation",
+    "",
+    "### Levels",
+    "| Level | Use | Shadow |",
+    "| --- | --- | --- |",
+    ...doc.depth.levels.map(
+      (level) => `| ${level.level} | ${level.use} | \`${level.shadow}\` |`,
+    ),
+    "",
+    "### Philosophy",
+    doc.depth.philosophy,
+    "",
+    "## 7. Interaction & Motion",
+    "",
+    "### Hover States",
+    doc.interaction.hoverStates,
+    "",
+    "### Focus States",
+    doc.interaction.focusStates,
+    "",
+    "### Transitions",
+    doc.interaction.transitions,
+    "",
+    "## 8. Responsive Behavior",
+    "",
+    "### Breakpoints",
+    "| Name | Min width | Primary changes |",
+    "| --- | --- | --- |",
+    ...doc.responsive.breakpoints.map(
+      (breakpoint) =>
+        `| ${breakpoint.name} | ${breakpoint.minWidth} | ${breakpoint.primaryChanges} |`,
+    ),
+    "",
+    "### Touch Targets",
+    doc.responsive.touchTargets,
+    "",
+    "### Collapsing Strategy",
+    doc.responsive.collapsingStrategy,
+    "",
+    "### Image Behavior",
+    doc.responsive.imageBehavior,
+    "",
+    "## 9. Agent Prompt Guide",
+    "",
+    "### Quick Color Reference",
+    "```text",
+    ...doc.agentPromptGuide.quickColorReference,
+    "```",
+    "",
+    "### Example Prompts",
+    ...renderBullets(doc.agentPromptGuide.examplePrompts),
+    "",
+    "### Iteration Guide",
+    ...renderBullets(doc.agentPromptGuide.iterationGuide),
+    "",
+  ];
+
+  return joinLines(lines);
+}

--- a/packages/tools/src/render/index.ts
+++ b/packages/tools/src/render/index.ts
@@ -12,38 +12,56 @@ function joinLines(lines: string[]): string {
   return `${lines.join(EOL).trimEnd()}${EOL}`;
 }
 
+function escapeInlineMarkdown(value: string): string {
+  return value
+    .replace(/`/g, "\\`")
+    .replace(/\r?\n/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeTableCell(value: string): string {
+  return escapeInlineMarkdown(value).replace(/\|/g, "\\|");
+}
+
+function escapeFenceText(value: string): string {
+  return value
+    .replace(/```/g, "`\u200B``")
+    .replace(/\r?\n/g, " ");
+}
+
 function renderColorGroup(group: ColorPaletteGroup): string[] {
   return [
-    `### ${group.heading}`,
+    `### ${escapeInlineMarkdown(group.heading)}`,
     "| Hex | Role | Where seen |",
     "| --- | --- | --- |",
     ...group.entries.map(
       (entry) =>
-        `| \`${entry.hex}\` | ${entry.role} | ${entry.whereSeen} |`,
+        `| \`${entry.hex}\` | ${escapeTableCell(entry.role)} | ${escapeTableCell(entry.whereSeen)} |`,
     ),
     "",
   ];
 }
 
 function renderTypographyRow(entry: TypographyHierarchyEntry): string {
-  return `| ${entry.role} | ${entry.font} | ${entry.size} | ${entry.weight} | ${entry.lineHeight} | ${entry.letterSpacing} |`;
+  return `| ${escapeTableCell(entry.role)} | ${escapeTableCell(entry.font)} | ${escapeTableCell(entry.size)} | ${escapeTableCell(entry.weight)} | ${escapeTableCell(entry.lineHeight)} | ${escapeTableCell(entry.letterSpacing)} |`;
 }
 
 function renderButton(button: ButtonStyle): string[] {
   return [
-    `- **${button.variant}** — background: ${button.background}; text: ${button.textColor}; border: ${button.border}; radius: ${button.radius}; padding: ${button.padding}; hover: ${button.hoverShift}`,
+    `- **${escapeInlineMarkdown(button.variant)}** — background: ${escapeInlineMarkdown(button.background)}; text: ${escapeInlineMarkdown(button.textColor)}; border: ${escapeInlineMarkdown(button.border)}; radius: ${escapeInlineMarkdown(button.radius)}; padding: ${escapeInlineMarkdown(button.padding)}; hover: ${escapeInlineMarkdown(button.hoverShift)}`,
   ];
 }
 
 function renderBullets(items: string[]): string[] {
-  return items.map((item) => `- ${item}`);
+  return items.map((item) => `- ${escapeInlineMarkdown(item)}`);
 }
 
 export function renderDesignMd(input: DesignDoc): string {
   const doc = designDocSchema.parse(input);
 
   const lines: string[] = [
-    `# ${doc.siteName} Design System`,
+    `# ${escapeInlineMarkdown(doc.siteName)} Design System`,
     "",
     "## 1. Visual Theme & Atmosphere",
     "",
@@ -95,7 +113,7 @@ export function renderDesignMd(input: DesignDoc): string {
     "",
     "### Distinctive",
     ...doc.components.distinctive.flatMap((component) => [
-      `- **${component.name}** — ${component.description}`,
+      `- **${escapeInlineMarkdown(component.name)}** — ${escapeInlineMarkdown(component.description)}`,
     ]),
     "",
     "## 5. Layout Principles",
@@ -118,7 +136,7 @@ export function renderDesignMd(input: DesignDoc): string {
     "| Level | Use | Shadow |",
     "| --- | --- | --- |",
     ...doc.depth.levels.map(
-      (level) => `| ${level.level} | ${level.use} | \`${level.shadow}\` |`,
+      (level) => `| ${escapeTableCell(level.level)} | ${escapeTableCell(level.use)} | \`${escapeInlineMarkdown(level.shadow)}\` |`,
     ),
     "",
     "### Philosophy",
@@ -142,7 +160,7 @@ export function renderDesignMd(input: DesignDoc): string {
     "| --- | --- | --- |",
     ...doc.responsive.breakpoints.map(
       (breakpoint) =>
-        `| ${breakpoint.name} | ${breakpoint.minWidth} | ${breakpoint.primaryChanges} |`,
+        `| ${escapeTableCell(breakpoint.name)} | ${escapeTableCell(breakpoint.minWidth)} | ${escapeTableCell(breakpoint.primaryChanges)} |`,
     ),
     "",
     "### Touch Targets",
@@ -158,7 +176,7 @@ export function renderDesignMd(input: DesignDoc): string {
     "",
     "### Quick Color Reference",
     "```text",
-    ...doc.agentPromptGuide.quickColorReference,
+    ...doc.agentPromptGuide.quickColorReference.map(escapeFenceText),
     "```",
     "",
     "### Example Prompts",

--- a/packages/tools/test/tools.test.ts
+++ b/packages/tools/test/tools.test.ts
@@ -1,0 +1,267 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  crawlSite,
+  buildDaytonaOpenUrlCommand,
+  buildSnapshotTag,
+  extractDesignTokens,
+  renderDesignMd,
+} from "../src";
+
+test("crawlSite resolves linked stylesheets and inline style blocks", async () => {
+  const html = `
+    <html>
+      <head>
+        <link rel="stylesheet" href="/styles/app.css" />
+        <style>:root { --brand: #5E6AD2; }</style>
+      </head>
+      <body></body>
+    </html>
+  `;
+
+  const stylesheet = `
+    @import url("./theme.css");
+    body { background: #0A0A0A; color: #FAFAFA; }
+  `;
+
+  const theme = `
+    @font-face {
+      font-family: "Inter";
+      src: url("/fonts/inter.woff2") format("woff2");
+      font-weight: 400 700;
+    }
+
+    @media (min-width: 1024px) {
+      .grid { gap: 24px; }
+    }
+  `;
+
+  const seen: string[] = [];
+  const crawl = await crawlSite({
+    url: "https://example.com",
+    fetch: async (url) => {
+      seen.push(url);
+      if (url === "https://example.com") return new Response(html);
+      if (url === "https://example.com/styles/app.css") {
+        return new Response(stylesheet);
+      }
+      if (url === "https://example.com/styles/theme.css") return new Response(theme);
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  });
+
+  assert.deepEqual(seen, [
+    "https://example.com",
+    "https://example.com/styles/app.css",
+    "https://example.com/styles/theme.css",
+  ]);
+  assert.equal(crawl.stylesheets.length, 3);
+  assert.ok(crawl.stylesheets.some((asset) => asset.kind === "imported"));
+  assert.ok(crawl.stylesheets.some((asset) => asset.kind === "inline"));
+});
+
+test("extractDesignTokens derives a grounded token set", () => {
+  const crawl = {
+    sourceUrl: "https://example.com",
+    siteName: "Example",
+    html: "<html><head><title>Example</title></head><body></body></html>",
+    stylesheets: [
+      {
+        kind: "linked" as const,
+        source: "https://example.com/styles.css",
+        content: `
+          @font-face {
+            font-family: "Inter";
+            src: url("/fonts/inter.woff2") format("woff2");
+            font-weight: 400;
+          }
+
+          :root {
+            --bg: #0A0A0A;
+            --fg: #FAFAFA;
+            --accent: #5E6AD2;
+            --radius-lg: 16px;
+          }
+
+          body {
+            background: var(--bg);
+            color: var(--fg);
+            font-family: Inter, sans-serif;
+            font-size: 16px;
+            line-height: 1.6;
+          }
+
+          .button {
+            background: #5E6AD2;
+            color: #FAFAFA;
+            padding: 12px 18px;
+            border-radius: 999px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+          }
+
+          .card {
+            background: #16171B;
+            border: 1px solid #26282C;
+            border-radius: 16px;
+            padding: 24px;
+          }
+
+          @media (min-width: 1024px) {
+            .layout { gap: 32px; }
+          }
+        `,
+        url: "https://example.com/styles.css",
+      },
+    ],
+    sourceUrls: ["https://example.com", "https://example.com/styles.css"],
+    notes: [],
+  };
+
+  const tokens = extractDesignTokens({
+    sourceUrl: "https://example.com",
+    crawlResult: crawl,
+    siteName: "Example",
+  });
+
+  assert.equal(tokens.siteName, "Example");
+  assert.equal(tokens.colors.accent[0]?.hex, "#5E6AD2");
+  assert.equal(tokens.typography.fontFamilies[0]?.family, "Inter");
+  assert.equal(tokens.breakpoints[0]?.minWidth, "1024px");
+});
+
+test("renderDesignMd outputs the required 9 sections in order", () => {
+  const markdown = renderDesignMd({
+    siteName: "Example",
+    sourceUrl: "https://example.com",
+    visualTheme: {
+      overview: [
+        "Dark-first and technical with a clear product focus.",
+        "Accent usage stays concentrated around primary actions and state changes.",
+      ],
+      keyCharacteristics: [
+        "Dark neutral base",
+        "Single vivid accent",
+        "Hairline borders",
+        "Rounded media",
+        "Calm motion",
+      ],
+    },
+    palette: {
+      philosophy: "A restrained neutral system holds the layout together while one accent color marks importance.",
+      groups: [
+        {
+          heading: "Primary",
+          entries: [{ hex: "#0A0A0A", role: "Surface base", whereSeen: "body" }],
+        },
+      ],
+      notes: "Accent is reserved for buttons and active states.",
+    },
+    typography: {
+      summary: "Inter drives both display and body typography.",
+      hierarchy: [
+        {
+          role: "Body",
+          font: "Inter",
+          size: "16px",
+          weight: "400",
+          lineHeight: "1.6",
+          letterSpacing: "0",
+        },
+      ],
+      principles: ["Tight display tracking.", "Readable measures.", "Limited weight range."],
+    },
+    components: {
+      buttons: [
+        {
+          variant: "primary",
+          background: "#5E6AD2",
+          textColor: "#FAFAFA",
+          border: "1px solid #5E6AD2",
+          radius: "999px",
+          padding: "12px 18px",
+          hoverShift: "Slight darken and raise.",
+        },
+      ],
+      cards: { description: "Raised cards with quiet borders.", tokens: ["Radius: 16px"] },
+      inputs: { description: "Low-contrast fields with visible focus rings.", tokens: ["Ring: 2px accent"] },
+      navigation: { description: "Horizontal desktop nav with active emphasis.", tokens: ["Sticky header"] },
+      imageTreatment: { description: "Rounded images with no decorative framing.", tokens: ["Radius: 20px"] },
+      distinctive: [
+        { name: "Hero panel", description: "Large framing around the lead narrative." },
+        { name: "Feature card", description: "Compact bordered summary blocks." },
+      ],
+    },
+    layout: {
+      spacingScale: "Uses 8px-derived spacing with 12px and 24px supporting steps.",
+      grid: "Wide centered container that relaxes into fewer columns on smaller screens.",
+      whitespace: "Generous section spacing balances denser internal card layouts.",
+      radiusScale: "Medium and large radii dominate, with pill buttons for actions.",
+    },
+    depth: {
+      levels: [{ level: "1", use: "Cards", shadow: "0 8px 24px rgba(0,0,0,0.12)" }],
+      philosophy: "Depth stays soft and secondary to borders and tonal separation.",
+    },
+    interaction: {
+      hoverStates: "Buttons darken slightly and lift by 1px.",
+      focusStates: "Accent rings remain clearly visible on keyboard focus.",
+      transitions: "Short ease-out transitions cover color, opacity, and transform.",
+    },
+    responsive: {
+      breakpoints: [{ name: "lg", minWidth: "1024px", primaryChanges: "More columns and expanded nav." }],
+      touchTargets: "Primary tap targets stay at or above 44px.",
+      collapsingStrategy: "Navigation condenses and dense grids simplify on narrow screens.",
+      imageBehavior: "Media scales proportionally and preserves primary focal content.",
+    },
+    agentPromptGuide: {
+      quickColorReference: [
+        "#0A0A0A // surface-base",
+        "#16171B // surface-raised",
+        "#5E6AD2 // accent-primary",
+        "#FAFAFA // text-inverse",
+        "#26282C // border-subtle",
+        "#10B981 // semantic-success",
+      ],
+      examplePrompts: [
+        "Build a dark landing page with #5E6AD2 CTAs and neutral cards.",
+        "Use Inter with tight spacing and pill buttons for the action layer.",
+        "Prefer quiet borders and restrained motion for emphasis.",
+      ],
+      iterationGuide: [
+        "Keep the accent reserved for emphasis.",
+        "Preserve the 8px rhythm.",
+        "Favor borders over stronger shadows.",
+        "Use larger radii on cards than on inputs.",
+      ],
+    },
+  });
+
+  const headings = [
+    "## 1. Visual Theme & Atmosphere",
+    "## 2. Color Palette & Roles",
+    "## 3. Typography Rules",
+    "## 4. Component Stylings",
+    "## 5. Layout Principles",
+    "## 6. Depth & Elevation",
+    "## 7. Interaction & Motion",
+    "## 8. Responsive Behavior",
+    "## 9. Agent Prompt Guide",
+  ];
+
+  for (const heading of headings) {
+    assert.ok(markdown.includes(heading), `missing heading: ${heading}`);
+  }
+
+  assert.ok(markdown.indexOf(headings[0]) < markdown.indexOf(headings[8]));
+});
+
+test("daytonaOpenUrlCommand quotes the target URL", () => {
+  const command = buildDaytonaOpenUrlCommand(
+    "https://example.com/path?utm=1&name=test",
+  );
+
+  assert.ok(command.includes("chromium"));
+  assert.ok(command.includes("\"https://example.com/path?utm=1&name=test\""));
+  assert.equal(buildSnapshotTag("ac10286"), "getdesign-ac10286");
+});

--- a/packages/tools/test/tools.test.ts
+++ b/packages/tools/test/tools.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   crawlSite,
-  buildDaytonaOpenUrlCommand,
+  daytonaOpenUrlCommand,
   buildSnapshotTag,
   extractDesignTokens,
   renderDesignMd,
@@ -257,7 +257,7 @@ test("renderDesignMd outputs the required 9 sections in order", () => {
 });
 
 test("daytonaOpenUrlCommand quotes the target URL", () => {
-  const command = buildDaytonaOpenUrlCommand(
+  const command = daytonaOpenUrlCommand(
     "https://example.com/path?utm=1&name=test",
   );
 

--- a/packages/tools/test/tools.test.ts
+++ b/packages/tools/test/tools.test.ts
@@ -5,6 +5,7 @@ import {
   crawlSite,
   daytonaOpenUrlCommand,
   buildSnapshotTag,
+  deriveSiteName,
   extractDesignTokens,
   renderDesignMd,
 } from "../src";
@@ -60,6 +61,40 @@ test("crawlSite resolves linked stylesheets and inline style blocks", async () =
   assert.equal(crawl.stylesheets.length, 3);
   assert.ok(crawl.stylesheets.some((asset) => asset.kind === "imported"));
   assert.ok(crawl.stylesheets.some((asset) => asset.kind === "inline"));
+});
+
+test("crawlSite blocks redirects to private targets", async () => {
+  await assert.rejects(
+    () =>
+      crawlSite({
+        url: "https://example.com",
+        fetch: async (url, init) => {
+          assert.equal(init?.redirect, "manual");
+          assert.equal(url, "https://example.com");
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location: "https://127.0.0.1/private.css",
+            },
+          });
+        },
+      }),
+    /Blocked redirect target/,
+  );
+});
+
+test("deriveSiteName falls back when the cleaned title is empty", () => {
+  const html = `
+    <html>
+      <head><title>| Example</title></head>
+      <body></body>
+    </html>
+  `;
+
+  assert.equal(
+    deriveSiteName(html, "https://www.example.com"),
+    "example.com",
+  );
 });
 
 test("extractDesignTokens derives a grounded token set", () => {
@@ -131,6 +166,50 @@ test("extractDesignTokens derives a grounded token set", () => {
   assert.equal(tokens.breakpoints[0]?.minWidth, "1024px");
 });
 
+test("extractDesignTokens merges repeated font-face weights and preserves inline stylesheet sources", () => {
+  const tokens = extractDesignTokens({
+    sourceUrl: "https://example.com",
+    html: "<html><head><title>Example</title></head><body></body></html>",
+    stylesheets: [
+      {
+        kind: "linked",
+        source: "https://example.com/styles.css",
+        url: "https://example.com/styles.css",
+        content: `
+          @font-face {
+            font-family: "Inter";
+            src: url("/fonts/inter-regular.woff2") format("woff2");
+            font-weight: 400;
+          }
+
+          @font-face {
+            font-family: "Inter";
+            src: url("/fonts/inter-bold.woff2") format("woff2");
+            font-weight: 700;
+          }
+        `,
+      },
+      {
+        kind: "inline",
+        source: "inline-style-1",
+        content: `
+          body {
+            font-family: Inter, sans-serif;
+            font-size: 16px;
+            color: #111111;
+          }
+        `,
+      },
+    ],
+  });
+
+  assert.deepEqual(tokens.sources, [
+    "https://example.com/styles.css",
+    "https://example.com",
+  ]);
+  assert.deepEqual(tokens.typography.fontFamilies[0]?.weights, ["400", "700"]);
+});
+
 test("renderDesignMd outputs the required 9 sections in order", () => {
   const markdown = renderDesignMd({
     siteName: "Example",
@@ -153,7 +232,7 @@ test("renderDesignMd outputs the required 9 sections in order", () => {
       groups: [
         {
           heading: "Primary",
-          entries: [{ hex: "#0A0A0A", role: "Surface base", whereSeen: "body" }],
+          entries: [{ hex: "#0A0A0A", role: "Surface | base", whereSeen: "body\nhero" }],
         },
       ],
       notes: "Accent is reserved for buttons and active states.",
@@ -216,7 +295,7 @@ test("renderDesignMd outputs the required 9 sections in order", () => {
     },
     agentPromptGuide: {
       quickColorReference: [
-        "#0A0A0A // surface-base",
+        "#0A0A0A // surface ``` base",
         "#16171B // surface-raised",
         "#5E6AD2 // accent-primary",
         "#FAFAFA // text-inverse",
@@ -254,14 +333,19 @@ test("renderDesignMd outputs the required 9 sections in order", () => {
   }
 
   assert.ok(markdown.indexOf(headings[0]) < markdown.indexOf(headings[8]));
+  assert.ok(markdown.includes("Surface \\| base"));
+  assert.ok(markdown.includes("body hero"));
+  assert.match(markdown, /`\u200B``/u);
 });
 
 test("daytonaOpenUrlCommand quotes the target URL", () => {
   const command = daytonaOpenUrlCommand(
-    "https://example.com/path?utm=1&name=test",
+    "https://example.com/path?utm=1&name=$(id)",
   );
 
   assert.ok(command.includes("chromium"));
-  assert.ok(command.includes("\"https://example.com/path?utm=1&name=test\""));
+  assert.ok(command.includes("DISPLAY=':1'"));
+  assert.ok(command.includes("'https://example.com/path?utm=1&name=$(id)'"));
+  assert.ok(!command.includes("\"https://example.com/path?utm=1&name=$(id)\""));
   assert.equal(buildSnapshotTag("ac10286"), "getdesign-ac10286");
 });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,8 @@
     "zod": "^4.3.6"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test"
   },
   "devDependencies": {
     "@getdesign/config": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,22 +1,37 @@
 {
   "name": "@getdesign/types",
   "version": "0.1.0",
-  "private": true,
   "description": "Shared placeholder types and schemas for getdesign packages.",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./design-tokens": "./src/design-tokens.ts",
-    "./design-doc": "./src/design-doc.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./design-tokens": {
+      "types": "./dist/design-tokens.d.ts",
+      "import": "./dist/design-tokens.js"
+    },
+    "./design-doc": {
+      "types": "./dist/design-doc.d.ts",
+      "import": "./dist/design-doc.js"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "zod": "^4.3.6"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "bun test"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "@getdesign/config": "workspace:*",

--- a/packages/types/src/design-doc.ts
+++ b/packages/types/src/design-doc.ts
@@ -49,7 +49,7 @@ export const buttonStyleSchema = z
 const namedComponentStyleSchema = z
   .object({
     description: markdownParagraphSchema,
-    tokens: markdownListSchema.default([]),
+    tokens: markdownListSchema,
   })
   .strict();
 

--- a/packages/types/src/design-doc.ts
+++ b/packages/types/src/design-doc.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+import { breakpointTokenSchema, colorTokenSchema, designTokensSchema, shadowTokenSchema } from "./design-tokens";
+
+const nonEmptyTextSchema = z.string().trim().min(1);
+
+const markdownParagraphSchema = nonEmptyTextSchema;
+const markdownListSchema = z.array(nonEmptyTextSchema).min(1);
+
+export const colorRoleEntrySchema = z
+  .object({
+    hex: colorTokenSchema.shape.hex,
+    role: nonEmptyTextSchema,
+    whereSeen: nonEmptyTextSchema,
+  })
+  .strict();
+
+export const colorPaletteGroupSchema = z
+  .object({
+    heading: nonEmptyTextSchema,
+    entries: z.array(colorRoleEntrySchema).min(1),
+  })
+  .strict();
+
+export const typographyHierarchyEntrySchema = z
+  .object({
+    role: nonEmptyTextSchema,
+    font: nonEmptyTextSchema,
+    size: nonEmptyTextSchema,
+    weight: nonEmptyTextSchema,
+    lineHeight: nonEmptyTextSchema,
+    letterSpacing: nonEmptyTextSchema,
+    notes: nonEmptyTextSchema.optional(),
+  })
+  .strict();
+
+export const buttonStyleSchema = z
+  .object({
+    variant: nonEmptyTextSchema,
+    background: nonEmptyTextSchema,
+    textColor: nonEmptyTextSchema,
+    border: nonEmptyTextSchema,
+    radius: nonEmptyTextSchema,
+    padding: nonEmptyTextSchema,
+    hoverShift: nonEmptyTextSchema,
+  })
+  .strict();
+
+const namedComponentStyleSchema = z
+  .object({
+    description: markdownParagraphSchema,
+    tokens: markdownListSchema.default([]),
+  })
+  .strict();
+
+export const distinctiveComponentSchema = z
+  .object({
+    name: nonEmptyTextSchema,
+    description: markdownParagraphSchema,
+  })
+  .strict();
+
+export const depthLevelSchema = z
+  .object({
+    level: nonEmptyTextSchema,
+    use: nonEmptyTextSchema,
+    shadow: shadowTokenSchema.shape.value.or(nonEmptyTextSchema),
+  })
+  .strict();
+
+export const responsiveBreakpointSchema = z
+  .object({
+    name: nonEmptyTextSchema,
+    minWidth: breakpointTokenSchema.shape.minWidth,
+    primaryChanges: nonEmptyTextSchema,
+  })
+  .strict();
+
+export const designDocSchema = z
+  .object({
+    siteName: nonEmptyTextSchema,
+    sourceUrl: z.string().url(),
+    visualTheme: z
+      .object({
+        overview: markdownListSchema.min(2).max(4),
+        keyCharacteristics: z.array(nonEmptyTextSchema).min(5).max(8),
+      })
+      .strict(),
+    palette: z
+      .object({
+        philosophy: markdownParagraphSchema,
+        groups: z.array(colorPaletteGroupSchema).min(1),
+        notes: markdownParagraphSchema,
+      })
+      .strict(),
+    typography: z
+      .object({
+        summary: markdownParagraphSchema,
+        hierarchy: z.array(typographyHierarchyEntrySchema).min(1),
+        principles: z.array(nonEmptyTextSchema).min(3).max(6),
+      })
+      .strict(),
+    components: z
+      .object({
+        buttons: z.array(buttonStyleSchema).min(1),
+        cards: namedComponentStyleSchema,
+        inputs: namedComponentStyleSchema,
+        navigation: namedComponentStyleSchema,
+        imageTreatment: namedComponentStyleSchema,
+        distinctive: z.array(distinctiveComponentSchema).min(2).max(4),
+      })
+      .strict(),
+    layout: z
+      .object({
+        spacingScale: markdownParagraphSchema,
+        grid: markdownParagraphSchema,
+        whitespace: markdownParagraphSchema,
+        radiusScale: markdownParagraphSchema,
+      })
+      .strict(),
+    depth: z
+      .object({
+        levels: z.array(depthLevelSchema).min(1),
+        philosophy: markdownParagraphSchema,
+      })
+      .strict(),
+    interaction: z
+      .object({
+        hoverStates: markdownParagraphSchema,
+        focusStates: markdownParagraphSchema,
+        transitions: markdownParagraphSchema,
+      })
+      .strict(),
+    responsive: z
+      .object({
+        breakpoints: z.array(responsiveBreakpointSchema).min(1),
+        touchTargets: markdownParagraphSchema,
+        collapsingStrategy: markdownParagraphSchema,
+        imageBehavior: markdownParagraphSchema,
+      })
+      .strict(),
+    agentPromptGuide: z
+      .object({
+        quickColorReference: z.array(nonEmptyTextSchema).min(6).max(12),
+        examplePrompts: z.array(nonEmptyTextSchema).length(3),
+        iterationGuide: z.array(nonEmptyTextSchema).min(4).max(6),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const renderedDesignResultSchema = z
+  .object({
+    runId: nonEmptyTextSchema,
+    markdown: nonEmptyTextSchema,
+    doc: designDocSchema,
+    tokens: designTokensSchema.optional(),
+  })
+  .strict();
+
+export type ColorRoleEntry = z.infer<typeof colorRoleEntrySchema>;
+export type ColorPaletteGroup = z.infer<typeof colorPaletteGroupSchema>;
+export type TypographyHierarchyEntry = z.infer<typeof typographyHierarchyEntrySchema>;
+export type ButtonStyle = z.infer<typeof buttonStyleSchema>;
+export type DistinctiveComponent = z.infer<typeof distinctiveComponentSchema>;
+export type DepthLevel = z.infer<typeof depthLevelSchema>;
+export type ResponsiveBreakpoint = z.infer<typeof responsiveBreakpointSchema>;
+export type DesignDoc = z.infer<typeof designDocSchema>;
+export type RenderedDesignResult = z.infer<typeof renderedDesignResultSchema>;

--- a/packages/types/src/design-tokens.ts
+++ b/packages/types/src/design-tokens.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+const nonEmptyTextSchema = z.string().trim().min(1);
+
+export const hexColorSchema = z.string().regex(
+  /^#(?:[\dA-Fa-f]{3}|[\dA-Fa-f]{4}|[\dA-Fa-f]{6}|[\dA-Fa-f]{8})$/,
+  "Expected a CSS hex color.",
+);
+
+export const tokenSourceSchema = nonEmptyTextSchema;
+
+export const colorTokenSchema = z
+  .object({
+    hex: hexColorSchema,
+    role: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const semanticColorTokensSchema = z
+  .object({
+    success: z.array(colorTokenSchema),
+    warning: z.array(colorTokenSchema),
+    error: z.array(colorTokenSchema),
+    info: z.array(colorTokenSchema),
+  })
+  .strict();
+
+export const fontFamilyTokenSchema = z
+  .object({
+    family: nonEmptyTextSchema,
+    role: z.enum(["display", "body", "mono", "accent", "ui"]),
+    source: tokenSourceSchema,
+    weights: z.array(nonEmptyTextSchema).default([]),
+  })
+  .strict();
+
+export const typeScaleTokenSchema = z
+  .object({
+    role: nonEmptyTextSchema,
+    size: nonEmptyTextSchema,
+    weight: nonEmptyTextSchema,
+    lineHeight: nonEmptyTextSchema,
+    letterSpacing: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const spacingTokenSchema = z
+  .object({
+    value: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+    usageCount: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export const radiusTokenSchema = z
+  .object({
+    name: nonEmptyTextSchema,
+    value: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const shadowTokenSchema = z
+  .object({
+    value: nonEmptyTextSchema,
+    role: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const borderTokenSchema = z
+  .object({
+    width: nonEmptyTextSchema,
+    style: nonEmptyTextSchema.optional(),
+    color: hexColorSchema,
+    role: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const breakpointTokenSchema = z
+  .object({
+    name: nonEmptyTextSchema.optional(),
+    minWidth: nonEmptyTextSchema,
+    source: tokenSourceSchema,
+  })
+  .strict();
+
+export const designTokensSchema = z
+  .object({
+    siteName: nonEmptyTextSchema,
+    sourceUrl: z.string().url(),
+    sources: z.array(z.string().url()).min(1),
+    colors: z
+      .object({
+        primary: z.array(colorTokenSchema),
+        accent: z.array(colorTokenSchema),
+        neutral: z.array(colorTokenSchema),
+        semantic: semanticColorTokensSchema,
+        surfaces: z.array(colorTokenSchema),
+        borders: z.array(colorTokenSchema),
+      })
+      .strict(),
+    typography: z
+      .object({
+        fontFamilies: z.array(fontFamilyTokenSchema).min(1),
+        scale: z.array(typeScaleTokenSchema).min(1),
+      })
+      .strict(),
+    spacing: z.array(spacingTokenSchema),
+    radii: z.array(radiusTokenSchema),
+    shadows: z.array(shadowTokenSchema),
+    borders: z.array(borderTokenSchema),
+    breakpoints: z.array(breakpointTokenSchema),
+  })
+  .strict();
+
+export type ColorToken = z.infer<typeof colorTokenSchema>;
+export type SemanticColorTokens = z.infer<typeof semanticColorTokensSchema>;
+export type FontFamilyToken = z.infer<typeof fontFamilyTokenSchema>;
+export type TypeScaleToken = z.infer<typeof typeScaleTokenSchema>;
+export type SpacingToken = z.infer<typeof spacingTokenSchema>;
+export type RadiusToken = z.infer<typeof radiusTokenSchema>;
+export type ShadowToken = z.infer<typeof shadowTokenSchema>;
+export type BorderToken = z.infer<typeof borderTokenSchema>;
+export type BreakpointToken = z.infer<typeof breakpointTokenSchema>;
+export type DesignTokens = z.infer<typeof designTokensSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,2 @@
-// @getdesign/types - Zod schemas for DesignTokens and DesignDoc.
-// See architecture.md §5 for the 9-section DesignDoc schema.
-export {};
+export * from "./design-doc";
+export * from "./design-tokens";

--- a/packages/types/test/schema.test.ts
+++ b/packages/types/test/schema.test.ts
@@ -1,0 +1,273 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { designDocSchema, designTokensSchema } from "../src";
+
+test("designTokensSchema parses grounded token payloads", () => {
+  const result = designTokensSchema.parse({
+    siteName: "Cursor",
+    sourceUrl: "https://cursor.com",
+    sources: ["https://cursor.com", "https://cursor.com/styles.css"],
+    colors: {
+      primary: [{ hex: "#0A0A0A", role: "surface base", source: ":root --bg" }],
+      accent: [{ hex: "#5E6AD2", role: "primary CTA", source: ":root --accent" }],
+      neutral: [{ hex: "#FAFAFA", role: "text inverse", source: "body" }],
+      semantic: {
+        success: [{ hex: "#10B981", role: "success badge", source: ".success" }],
+        warning: [],
+        error: [{ hex: "#EF4444", role: "error banner", source: ".error" }],
+        info: [],
+      },
+      surfaces: [{ hex: "#16171B", role: "surface raised", source: ".card" }],
+      borders: [{ hex: "#26282C", role: "border subtle", source: ".card" }],
+    },
+    typography: {
+      fontFamilies: [
+        {
+          family: "Inter",
+          role: "body",
+          source: "@font-face",
+          weights: ["400", "500", "600"],
+        },
+      ],
+      scale: [
+        {
+          role: "Body",
+          size: "16px",
+          weight: "400",
+          lineHeight: "1.6",
+          letterSpacing: "0",
+          source: "body",
+        },
+      ],
+    },
+    spacing: [{ value: "8px", source: ".stack", usageCount: 4 }],
+    radii: [{ name: "md", value: "12px", source: ":root --radius-md" }],
+    shadows: [{ value: "0 4px 12px rgba(0,0,0,0.08)", role: "card", source: ".card" }],
+    borders: [
+      {
+        width: "1px",
+        style: "solid",
+        color: "#26282C",
+        role: "card border",
+        source: ".card",
+      },
+    ],
+    breakpoints: [{ name: "lg", minWidth: "1024px", source: "@media (min-width: 1024px)" }],
+  });
+
+  assert.equal(result.colors.accent[0]?.hex, "#5E6AD2");
+  assert.equal(result.typography.fontFamilies[0]?.family, "Inter");
+});
+
+test("designDocSchema enforces the 9-section contract", () => {
+  const result = designDocSchema.parse({
+    siteName: "Cursor",
+    sourceUrl: "https://cursor.com",
+    visualTheme: {
+      overview: [
+        "Dark-first and technical, with a calm but assertive product voice.",
+        "Minimal surfaces keep the accent hue reserved for calls to action and status changes.",
+      ],
+      keyCharacteristics: [
+        "Dark neutral surface ramp",
+        "Single vivid accent for actions",
+        "Hairline borders over heavy shadows",
+        "Tight display typography",
+        "Consistent 8px spacing rhythm",
+      ],
+    },
+    palette: {
+      philosophy: "Monochrome neutrals anchor the interface while one saturated accent carries emphasis.",
+      groups: [
+        {
+          heading: "Primary",
+          entries: [{ hex: "#0A0A0A", role: "Surface base", whereSeen: "body background" }],
+        },
+      ],
+      notes: "Accent usage stays concentrated in buttons, links, and active indicators.",
+    },
+    typography: {
+      summary: "Display and body typography share a tight, modern sans stack with restrained variation.",
+      hierarchy: [
+        {
+          role: "Body",
+          font: "Inter",
+          size: "16px",
+          weight: "400",
+          lineHeight: "1.6",
+          letterSpacing: "0",
+        },
+      ],
+      principles: [
+        "Display sizes use tighter tracking than body text.",
+        "Body copy keeps a readable measure.",
+        "Weights step up sparingly for emphasis.",
+      ],
+    },
+    components: {
+      buttons: [
+        {
+          variant: "primary",
+          background: "#5E6AD2",
+          textColor: "#FAFAFA",
+          border: "1px solid #5E6AD2",
+          radius: "999px",
+          padding: "12px 18px",
+          hoverShift: "Darken background slightly and raise by 1px.",
+        },
+      ],
+      cards: {
+        description: "Cards sit on a raised neutral surface with a quiet border.",
+        tokens: ["Surface: #16171B", "Radius: 16px"],
+      },
+      inputs: {
+        description: "Inputs use low-contrast fills and a visible accent ring on focus.",
+        tokens: ["Border: 1px solid #26282C", "Focus ring: 2px #5E6AD2"],
+      },
+      navigation: {
+        description: "Desktop navigation is horizontal with active states shown by contrast and accent.",
+        tokens: ["Sticky header", "Compact gap rhythm"],
+      },
+      imageTreatment: {
+        description: "Images keep rounded corners and avoid decorative frames.",
+        tokens: ["Radius: 20px", "High-contrast screenshots"],
+      },
+      distinctive: [
+        { name: "Hero terminal", description: "A code-like hero module pairs product copy with dense UI." },
+        { name: "Command cards", description: "Feature cards present actions in a compact, bordered layout." },
+      ],
+    },
+    layout: {
+      spacingScale: "The layout uses a predominantly 8px-based ramp with occasional 12px and 24px steps.",
+      grid: "Content centers within a wide max-width container and relaxes into fewer columns on narrow screens.",
+      whitespace: "Whitespace is generous in hero and section breaks, but denser within cards and command surfaces.",
+      radiusScale: "Corners cluster around medium and large rounded values, with pills reserved for buttons and chips.",
+    },
+    depth: {
+      levels: [{ level: "1", use: "Resting cards", shadow: "0 4px 12px rgba(0,0,0,0.08)" }],
+      philosophy: "Depth is subtle and mostly reinforced through tonal separation plus hairline borders.",
+    },
+    interaction: {
+      hoverStates: "Buttons and links shift color or opacity with restrained motion.",
+      focusStates: "Visible focus rings use the accent hue and remain present on keyboard navigation.",
+      transitions: "State changes favor short ease-out transitions on color, opacity, and transform.",
+    },
+    responsive: {
+      breakpoints: [{ name: "lg", minWidth: "1024px", primaryChanges: "Navigation expands and multi-column sections appear." }],
+      touchTargets: "Primary tap targets stay at or above 44px in height on mobile.",
+      collapsingStrategy: "Navigation condenses behind a hamburger while dense grids simplify to single-column stacks.",
+      imageBehavior: "Hero images preserve framing with object-fit cover semantics and scale down without cropping core content.",
+    },
+    agentPromptGuide: {
+      quickColorReference: [
+        "#0A0A0A // surface-base",
+        "#16171B // surface-raised",
+        "#5E6AD2 // accent-primary",
+        "#FAFAFA // text-inverse",
+        "#26282C // border-subtle",
+        "#10B981 // semantic-success",
+      ],
+      examplePrompts: [
+        "Build a dark product landing page using #0A0A0A backgrounds, #16171B cards, and #5E6AD2 primary CTAs.",
+        "Use tight sans-serif display typography, hairline borders, and restrained hover motion for a technical UI.",
+        "Create pill-shaped primary buttons and rounded screenshot cards with subtle neutral separation.",
+      ],
+      iterationGuide: [
+        "Keep the accent limited to actions and active states.",
+        "Prefer borders before adding deeper shadows.",
+        "Preserve the 8px spacing rhythm when expanding sections.",
+        "Use larger radii on screenshots and cards than on inputs.",
+      ],
+    },
+  });
+
+  assert.equal(result.agentPromptGuide.examplePrompts.length, 3);
+  assert.equal(result.palette.groups[0]?.heading, "Primary");
+});
+
+test("designDocSchema rejects incomplete visual theme characteristics", () => {
+  assert.throws(() =>
+    designDocSchema.parse({
+      siteName: "Broken",
+      sourceUrl: "https://example.com",
+      visualTheme: {
+        overview: ["Only one paragraph."],
+        keyCharacteristics: ["Only one characteristic."],
+      },
+      palette: {
+        philosophy: "x",
+        groups: [{ heading: "Primary", entries: [{ hex: "#000", role: "base", whereSeen: "body" }] }],
+        notes: "x",
+      },
+      typography: {
+        summary: "x",
+        hierarchy: [
+          {
+            role: "Body",
+            font: "Inter",
+            size: "16px",
+            weight: "400",
+            lineHeight: "1.6",
+            letterSpacing: "0",
+          },
+        ],
+        principles: ["a", "b", "c"],
+      },
+      components: {
+        buttons: [
+          {
+            variant: "primary",
+            background: "#000",
+            textColor: "#fff",
+            border: "1px solid #000",
+            radius: "999px",
+            padding: "12px 18px",
+            hoverShift: "none",
+          },
+        ],
+        cards: { description: "x", tokens: ["x"] },
+        inputs: { description: "x", tokens: ["x"] },
+        navigation: { description: "x", tokens: ["x"] },
+        imageTreatment: { description: "x", tokens: ["x"] },
+        distinctive: [
+          { name: "one", description: "x" },
+          { name: "two", description: "x" },
+        ],
+      },
+      layout: {
+        spacingScale: "x",
+        grid: "x",
+        whitespace: "x",
+        radiusScale: "x",
+      },
+      depth: {
+        levels: [{ level: "1", use: "Cards", shadow: "none" }],
+        philosophy: "x",
+      },
+      interaction: {
+        hoverStates: "x",
+        focusStates: "x",
+        transitions: "x",
+      },
+      responsive: {
+        breakpoints: [{ name: "sm", minWidth: "640px", primaryChanges: "x" }],
+        touchTargets: "x",
+        collapsingStrategy: "x",
+        imageBehavior: "x",
+      },
+      agentPromptGuide: {
+        quickColorReference: [
+          "#000000 // base",
+          "#111111 // raised",
+          "#222222 // accent",
+          "#333333 // text",
+          "#444444 // border",
+          "#555555 // success",
+        ],
+        examplePrompts: ["a", "b", "c"],
+        iterationGuide: ["a", "b", "c", "d"],
+      },
+    }),
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add the M1 shared contract in `@getdesign/types` with `DesignTokens` and `DesignDoc` Zod schemas, subpath exports, and focused schema tests
- implement the next two PRD deliveries in-repo by adding `@getdesign/tools` modules for `crawler`, `extractors`, `render`, and `daytona`, plus deterministic tests for crawl/token/render command behavior
- add `infra/daytona/Dockerfile` and `infra/daytona/README.md` as the first concrete Daytona snapshot assets, wire `@getdesign/sdk` to consume/re-export the shared contract types, and add a project-level `apps/web/.vercelignore` so unrelated repo noise does not affect the web app upload set

Closes #

## Surface(s) affected

- [x] SDK (`packages/sdk`)
- [x] Web (`apps/web`)
- [ ] HTTP API (`apps/api`)
- [ ] CLI (`apps/cli`)
- [ ] Agent skill (`skills/getdesign`)
- [x] Shared package (`agent` / `tools` / `types` / `ui` / `config`)
- [ ] Convex (`convex/`)
- [ ] Repo tooling / docs

## Breaking changes?

- [x] No
- [ ] Yes — migration notes:

## Screenshots / output samples

- `packages/types`: `bun test` passes for the schema contract fixture set.
- `packages/types`: `bun run typecheck` passes.
- `packages/sdk`: `bun run typecheck` passes.
- `packages/tools`: `bun test` passes for crawl, token extraction, markdown rendering, and Daytona command generation.
- `packages/tools`: `bun run typecheck` passes.
- `apps/web`: `bun run typecheck` passes after adding the project-level `.vercelignore`.

## Checklist

- [x] Conventional-commit title (e.g. `feat(skill): …`)
- [ ] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] If this changes the 9-section `design.md` contract, a maintainer has approved the schema change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e487d86-fada-4243-b323-b52230803438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e487d86-fada-4243-b323-b52230803438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added design token extraction capabilities to automatically discover and validate colors, typography, spacing, and other design system properties
  * Introduced design document rendering to structured markdown format
  * New visual capture sandbox integration for deterministic screenshot workflows

* **Documentation**
  * Published infrastructure documentation for the visual capture pipeline
  * Updated changelog with new tooling modules and skill definitions

* **Chores**
  * Optimized deployment build configuration
  * Enhanced package structure and type exports for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->