### PR TITLE
fix(studio): address deck workflow review comments

### DIFF
--- a/apps/studio/src/main/deck-plan-watcher.ts
+++ b/apps/studio/src/main/deck-plan-watcher.ts
@@ -61,7 +61,8 @@ export class DeckPlanWatcher {
       // deck-plan.json), and `fs.watch` errors on a missing path. Directory
       // watching catches creates, modifies, and renames uniformly.
       this.fsWatcher = watch(artifactPath, (_eventType, filename) => {
-        if (filename !== DECK_PLAN_FILE) return;
+        const watchedName = filename == null ? undefined : String(filename);
+        if (watchedName && watchedName !== DECK_PLAN_FILE) return;
         this.scheduleEmit();
       });
       this.fsWatcher.on("error", () => {

--- a/apps/studio/src/main/deck-service.test.ts
+++ b/apps/studio/src/main/deck-service.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import type { StudioDeckSlideContent } from "../shared/studio-api";
+import {
+  buildSlides,
+  getDeckDimensionsForMode,
+  renderSlideHtml,
+  renderTokensCss,
+} from "./deck-template-rendering";
+
+describe("deck-service generated deck helpers", () => {
+  test("preserves speaker notes in generated slide manifests", () => {
+    const slides = buildSlides([
+      {
+        label: "Intro",
+        title: "Welcome",
+        notes: "Open with the customer pain.",
+      },
+    ] satisfies StudioDeckSlideContent[]);
+
+    expect(slides[0]).toMatchObject({
+      file: "slides/01-intro.html",
+      notes: "Open with the customer pain.",
+    });
+  });
+
+  test("uses 1280x720 assets and tweaks css for pptx-safe starter slides", () => {
+    const [slide] = buildSlides([
+      {
+        label: "Cover",
+        title: "Launch",
+      },
+    ] satisfies StudioDeckSlideContent[]);
+
+    const html = renderSlideHtml({
+      title: "Launch deck",
+      slide: slide!,
+      content: { label: "Cover", title: "Launch" },
+      index: 0,
+      total: 1,
+      mode: "pptx-safe",
+    });
+
+    expect(getDeckDimensionsForMode("pptx-safe")).toEqual({ width: 1280, height: 720 });
+    expect(html).toContain('<meta name="viewport" content="width=1280,height=720">');
+    expect(html).toContain('<link rel="stylesheet" href="../shared/tweaks.css">');
+    expect(renderTokensCss("pptx-safe")).toContain("width: 1280px; height: 720px");
+  });
+
+  test("keeps freeform starter slides at 1920x1080", () => {
+    expect(getDeckDimensionsForMode("freeform")).toEqual({ width: 1920, height: 1080 });
+    expect(renderTokensCss("freeform")).toContain("width: 1920px; height: 1080px");
+  });
+});

--- a/apps/studio/src/main/deck-service.ts
+++ b/apps/studio/src/main/deck-service.ts
@@ -21,9 +21,15 @@ import {
   exportStudioDeckPptx,
   validateStudioPptxDeck,
 } from "./studio-pptx-export";
+import { waitForWebContentsVisualReady } from "./web-contents-ready";
+import {
+  buildSlides,
+  getDeckDimensionsForMode,
+  renderSlideHtml,
+  renderTokensCss,
+} from "./deck-template-rendering";
 
-const DECK_WIDTH = 1920;
-const DECK_HEIGHT = 1080;
+const DEFAULT_DECK_DIMENSIONS = getDeckDimensionsForMode("freeform");
 const TEMP_INDEX_MARKER = "studio-generated-temporary-index";
 const DECK_PLAN_FILE = "deck-plan.json";
 const VALID_EXPORT_PATHS = new Set(["html", "html-pdf", "pptx"]);
@@ -95,6 +101,7 @@ export class StudioDeckService {
 
     const slides = buildSlides(slideContents);
     await writeFile(join(sharedPath, "tokens.css"), renderTokensCss(mode), "utf8");
+    await writeTweaksCss(deckPath, {});
     await Promise.all(
       slides.map((slide, index) =>
         writeFile(
@@ -150,24 +157,25 @@ export class StudioDeckService {
     const hasSlideFiles = slides.some((slide) => slide.file.startsWith("slides/"));
     const plan = await readPlanFile(artifactPath);
 
-    // Plan-only "in planning" state: the agent wrote deck-plan.json but no
-    // slides exist yet. We return a deck so the renderer can show the Plan
-    // Gate Card (and its Confirm button) before the agent generates slides.
-    // This is the explicit hand-off the planning gate is built around.
     if (!hasSlideFiles) {
-      if (!plan) return undefined;
+      const stored = await readStoredManifest(artifactPath);
+      const hasIndexFile = await pathExists(indexFile);
+      if (!plan && !stored && !hasIndexFile) return undefined;
       const now = Date.now();
+      const manifest = await readArtifactManifest(artifactPath, artifactId, {
+        parsed: stored,
+        discoveredSlides: slides,
+      });
       return withPreviewUrl({
-        id: artifactId,
-        title: titleFromArtifactId(artifactId),
-        mode: plan.mode,
+        ...manifest,
+        mode: plan?.mode ?? manifest.mode,
         path: artifactPath,
         indexFile,
-        createdAt: plan.createdAt ?? now,
-        updatedAt: now,
-        slides: [],
+        createdAt: manifest.createdAt || plan?.createdAt || now,
+        updatedAt: Math.max(manifest.updatedAt || 0, now),
+        slides: stored || hasIndexFile ? manifest.slides : [],
         plan,
-        tweaks: {},
+        tweaks: manifest.tweaks,
       });
     }
 
@@ -233,12 +241,9 @@ export class StudioDeckService {
     const sanitized = sanitizePlanInput(planInput);
     const plan: StudioDeckPlan = {
       ...sanitized,
-      status: sanitized.status ?? existing?.status ?? "pending",
+      status: "pending",
       createdAt: existing?.createdAt ?? Date.now(),
-      confirmedAt:
-        sanitized.status === "confirmed" || existing?.status === "confirmed"
-          ? existing?.confirmedAt ?? Date.now()
-          : undefined,
+      confirmedAt: undefined,
     };
     await writePlanFile(deck.path, plan);
     return this.loadDeck(deckId);
@@ -282,7 +287,7 @@ export class StudioDeckService {
       indexFile: deck.indexFile,
       createdAt: stored.createdAt ?? deck.createdAt,
       updatedAt: Date.now(),
-      slides: stored.slides ?? deck.slides,
+      slides: deck.slides,
       tweaks: sanitized,
     };
     await writeManifest(deck.path, next);
@@ -379,19 +384,20 @@ const PPTX_SAFE_BANNED_SUBSTRINGS: ReadonlyArray<readonly [string, string]> = [
 async function readArtifactManifest(
   artifactPath: string,
   artifactId: string,
+  options: {
+    parsed?: Partial<StoredDeckManifest>;
+    discoveredSlides?: StudioDeckSlide[];
+  } = {},
 ): Promise<StoredDeckManifest> {
-  const deckJsonPath = join(artifactPath, "deck.json");
-  let parsed: Partial<StoredDeckManifest> = {};
-  try {
-    const raw = await readFile(deckJsonPath, "utf8");
-    parsed = JSON.parse(raw) as Partial<StoredDeckManifest>;
-  } catch {
-    // Artifact deck without explicit manifest — derive from filesystem.
-  }
+  const parsed = options.parsed ?? (await readStoredManifest(artifactPath)) ?? {};
 
-  const discovered = await discoverSlides(artifactPath);
-  const baseSlides =
-    parsed.slides && parsed.slides.length > 0 ? parsed.slides : discovered;
+  const discovered = options.discoveredSlides ?? (await discoverSlides(artifactPath));
+  const discoveredHasSlideFiles = discovered.some((slide) => slide.file.startsWith("slides/"));
+  const baseSlides = discoveredHasSlideFiles
+    ? mergeDiscoveredSlideMetadata(discovered, parsed.slides)
+    : parsed.slides && parsed.slides.length > 0
+      ? parsed.slides
+      : discovered;
   const slides = await hydrateSlideNotes(artifactPath, baseSlides);
 
   return {
@@ -405,6 +411,30 @@ async function readArtifactManifest(
     slides,
     tweaks: sanitizeTweaks(parsed.tweaks ?? {}),
   };
+}
+
+async function readStoredManifest(
+  artifactPath: string,
+): Promise<Partial<StoredDeckManifest> | undefined> {
+  try {
+    const raw = await readFile(join(artifactPath, "deck.json"), "utf8");
+    return JSON.parse(raw) as Partial<StoredDeckManifest>;
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeDiscoveredSlideMetadata(
+  discovered: StudioDeckSlide[],
+  stored: StudioDeckSlide[] | undefined,
+): StudioDeckSlide[] {
+  if (!stored || stored.length === 0) return discovered;
+  return discovered.map((slide) => {
+    const previous = stored.find(
+      (candidate) => candidate.file === slide.file || candidate.id === slide.id,
+    );
+    return previous?.notes ? { ...slide, notes: previous.notes } : slide;
+  });
 }
 
 async function discoverSlides(artifactPath: string): Promise<StudioDeckSlide[]> {
@@ -503,10 +533,7 @@ async function inferDeckDimensions(
 ): Promise<DeckDimensions> {
   const firstSlide = slides.find((slide) => slide.file.startsWith("slides/"));
   if (!firstSlide) {
-    return (await inferSharedStylesDimensions(artifactPath)) ?? {
-      width: DECK_WIDTH,
-      height: DECK_HEIGHT,
-    };
+    return (await inferSharedStylesDimensions(artifactPath)) ?? DEFAULT_DECK_DIMENSIONS;
   }
 
   try {
@@ -516,15 +543,9 @@ async function inferDeckDimensions(
       readCssDimensions(html, /body\s*\{([\s\S]*?)\}/i) ??
       readViewportDimensions(html);
     if (fromSlide) return fromSlide;
-    return (await inferSharedStylesDimensions(artifactPath)) ?? {
-      width: DECK_WIDTH,
-      height: DECK_HEIGHT,
-    };
+    return (await inferSharedStylesDimensions(artifactPath)) ?? DEFAULT_DECK_DIMENSIONS;
   } catch {
-    return (await inferSharedStylesDimensions(artifactPath)) ?? {
-      width: DECK_WIDTH,
-      height: DECK_HEIGHT,
-    };
+    return (await inferSharedStylesDimensions(artifactPath)) ?? DEFAULT_DECK_DIMENSIONS;
   }
 }
 
@@ -682,61 +703,12 @@ async function waitForPrintFramesReady(win: BrowserWindow): Promise<void> {
  * Falls back to a 1500ms ceiling so a hung page never wedges export forever.
  */
 function waitForDeckLoad(win: BrowserWindow): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    const ceiling = setTimeout(finish, 1500);
-    const ready = () => {
-      win.webContents
-        .executeJavaScript(
-          `(async () => {
-            try { if (document.fonts && document.fonts.ready) { await document.fonts.ready; } } catch (_) {}
-            await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-            return true;
-          })()`,
-        )
-        .then(() => {
-          clearTimeout(ceiling);
-          finish();
-        })
-        .catch(() => {
-          clearTimeout(ceiling);
-          finish();
-        });
-    };
-    if (win.webContents.isLoading()) {
-      win.webContents.once("did-finish-load", ready);
-      win.webContents.once("did-fail-load", () => {
-        clearTimeout(ceiling);
-        finish();
-      });
-    } else {
-      ready();
-    }
-  });
-}
-
-function buildSlides(contents: StudioDeckSlideContent[]): StudioDeckSlide[] {
-  const labels = ["Cover", "Narrative", "Problem", "Solution", "Proof", "Roadmap", "Closing"];
-  return contents.map((content, index) => {
-    const n = String(index + 1).padStart(2, "0");
-    const label = content.label?.trim() || labels[index] || `Slide ${index + 1}`;
-    return {
-      id: `slide-${n}`,
-      file: `slides/${n}-${slugify(label)}.html`,
-      label,
-      title: content.title,
-    };
-  });
+  return waitForWebContentsVisualReady(win.webContents, 1500);
 }
 
 function renderDeckIndex(
   slides: StudioDeckSlide[],
-  dimensions: DeckDimensions = { width: DECK_WIDTH, height: DECK_HEIGHT },
+  dimensions: DeckDimensions = DEFAULT_DECK_DIMENSIONS,
 ) {
   const manifest = slides
     .map((slide) => `    { file: ${JSON.stringify(slide.file)}, label: ${JSON.stringify(slide.label)} }`)
@@ -844,99 +816,6 @@ ${printFrames}
 `;
 }
 
-function renderSlideHtml({
-  title,
-  slide,
-  content,
-  index,
-  total,
-  mode,
-}: {
-  title: string;
-  slide: StudioDeckSlide;
-  content: StudioDeckSlideContent;
-  index: number;
-  total: number;
-  mode: StudioDeckMode;
-}) {
-  const isCover = index === 0;
-  const safeNote =
-    mode === "pptx-safe"
-      ? "PPTX-safe: text stays in p/h tags, images use img tags, gradients and web components are avoided."
-      : "Freeform HTML source: PDF and browser presentation are the primary exports.";
-
-  const points = (content.points && content.points.length > 0
-    ? content.points
-    : [
-        "Models learn statistical patterns from examples.",
-        "Training adjusts internal weights to reduce errors.",
-        "Inference applies those learned weights to new inputs.",
-      ]
-  ).slice(0, 5);
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=1920,height=1080">
-<title>${escapeHtml(title)} · ${escapeHtml(slide.label)}</title>
-<link rel="stylesheet" href="../shared/tokens.css">
-</head>
-<body>
-  <main class="slide ${isCover ? "cover" : ""}">
-    <header class="masthead">
-      <p>Studio Deck</p>
-      <p>${String(index + 1).padStart(2, "0")} / ${String(total).padStart(2, "0")}</p>
-    </header>
-    <section class="content">
-      <p class="kicker">${escapeHtml(slide.label)}</p>
-      <h1>${escapeHtml(content.title || (isCover ? title : slide.title))}</h1>
-      <p class="lede">${escapeHtml(content.lede || safeNote)}</p>
-      <div class="process">
-        ${points
-          .map(
-            (point, pointIndex) => `<article>
-          <p class="eyebrow">Step ${String(pointIndex + 1).padStart(2, "0")}</p>
-          <h2>${escapeHtml(point.split(":")[0] || point)}</h2>
-          <p>${escapeHtml(point.includes(":") ? point.split(":").slice(1).join(":").trim() : point)}</p>
-        </article>`,
-          )
-          .join("\n        ")}
-      </div>
-    </section>
-  </main>
-</body>
-</html>
-`;
-}
-
-function renderTokensCss(mode: StudioDeckMode) {
-  const background =
-    mode === "pptx-safe"
-      ? "#faf8f1"
-      : "radial-gradient(circle at 20% 0%, rgba(215,255,114,.18), transparent 30%), #faf8f1";
-  const kickerBorder =
-    mode === "pptx-safe"
-      ? ""
-      : "border: 1px solid rgba(23,23,20,.2); border-radius: 999px;";
-  return `* { box-sizing: border-box; }
-html, body { margin: 0; width: ${DECK_WIDTH}px; height: ${DECK_HEIGHT}px; overflow: hidden; }
-body { background: ${background}; color: #171714; font-family: Georgia, "Times New Roman", serif; }
-.slide { position: relative; width: ${DECK_WIDTH}px; height: ${DECK_HEIGHT}px; padding: 58px 76px 64px; }
-.masthead { display: flex; justify-content: space-between; border-bottom: 1px solid rgba(23,23,20,.18); padding-bottom: 18px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .12em; text-transform: uppercase; font-size: 16px; color: rgba(23,23,20,.55); }
-.content { height: calc(100% - 50px); display: flex; flex-direction: column; justify-content: center; gap: 28px; }
-.kicker { width: fit-content; ${kickerBorder} padding: 8px 14px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 15px; letter-spacing: .16em; text-transform: uppercase; }
-h1 { max-width: 1240px; margin: 0; font-size: 118px; line-height: .95; letter-spacing: -.055em; text-wrap: balance; }
-.cover h1 { max-width: 1500px; font-size: 150px; }
-.lede { max-width: 980px; margin: 0; font-size: 30px; line-height: 1.35; color: rgba(23,23,20,.72); text-wrap: pretty; }
-.process { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 28px; max-width: 1440px; margin-top: 12px; }
-article { border-top: 1px solid rgba(23,23,20,.18); padding-top: 22px; }
-.eyebrow { margin: 0 0 14px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 14px; letter-spacing: .14em; text-transform: uppercase; color: rgba(23,23,20,.5); }
-h2 { margin: 0 0 12px; font-size: 36px; letter-spacing: -.02em; }
-article p:last-child { margin: 0; max-width: 520px; font-size: 22px; line-height: 1.55; color: rgba(23,23,20,.68); }
-`;
-}
-
 function normalizeSlideContents(input: StudioCreateDeckInput): StudioDeckSlideContent[] {
   const provided = input.slides
     ?.filter((slide) => slide.title.trim().length > 0)
@@ -1038,6 +917,15 @@ async function writePlanFile(deckPath: string, plan: StudioDeckPlan): Promise<vo
     JSON.stringify(plan, null, 2),
     "utf8",
   );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isPlanRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/studio/src/main/deck-template-rendering.ts
+++ b/apps/studio/src/main/deck-template-rendering.ts
@@ -1,0 +1,147 @@
+import type {
+  StudioDeckMode,
+  StudioDeckSlide,
+  StudioDeckSlideContent,
+} from "../shared/studio-api";
+
+export type DeckDimensions = { width: number; height: number };
+
+const DECK_WIDTH = 1920;
+const DECK_HEIGHT = 1080;
+const PPTX_SAFE_DECK_WIDTH = 1280;
+const PPTX_SAFE_DECK_HEIGHT = 720;
+
+export function buildSlides(contents: StudioDeckSlideContent[]): StudioDeckSlide[] {
+  const labels = ["Cover", "Narrative", "Problem", "Solution", "Proof", "Roadmap", "Closing"];
+  return contents.map((content, index) => {
+    const n = String(index + 1).padStart(2, "0");
+    const label = content.label?.trim() || labels[index] || `Slide ${index + 1}`;
+    return {
+      id: `slide-${n}`,
+      file: `slides/${n}-${slugify(label)}.html`,
+      label,
+      title: content.title,
+      notes: content.notes?.trim() || undefined,
+    };
+  });
+}
+
+export function renderSlideHtml({
+  title,
+  slide,
+  content,
+  index,
+  total,
+  mode,
+}: {
+  title: string;
+  slide: StudioDeckSlide;
+  content: StudioDeckSlideContent;
+  index: number;
+  total: number;
+  mode: StudioDeckMode;
+}) {
+  const isCover = index === 0;
+  const dimensions = getDeckDimensionsForMode(mode);
+  const safeNote =
+    mode === "pptx-safe"
+      ? "PPTX-safe: text stays in p/h tags, images use img tags, gradients and web components are avoided."
+      : "Freeform HTML source: PDF and browser presentation are the primary exports.";
+
+  const points = (content.points && content.points.length > 0
+    ? content.points
+    : [
+        "Models learn statistical patterns from examples.",
+        "Training adjusts internal weights to reduce errors.",
+        "Inference applies those learned weights to new inputs.",
+      ]
+  ).slice(0, 5);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=${dimensions.width},height=${dimensions.height}">
+<title>${escapeHtml(title)} · ${escapeHtml(slide.label)}</title>
+<link rel="stylesheet" href="../shared/tokens.css">
+<link rel="stylesheet" href="../shared/tweaks.css">
+</head>
+<body>
+  <main class="slide ${isCover ? "cover" : ""}">
+    <header class="masthead">
+      <p>Studio Deck</p>
+      <p>${String(index + 1).padStart(2, "0")} / ${String(total).padStart(2, "0")}</p>
+    </header>
+    <section class="content">
+      <p class="kicker">${escapeHtml(slide.label)}</p>
+      <h1>${escapeHtml(content.title || (isCover ? title : slide.title))}</h1>
+      <p class="lede">${escapeHtml(content.lede || safeNote)}</p>
+      <div class="process">
+        ${points
+          .map(
+            (point, pointIndex) => `<article>
+          <p class="eyebrow">Step ${String(pointIndex + 1).padStart(2, "0")}</p>
+          <h2>${escapeHtml(point.split(":")[0] || point)}</h2>
+          <p>${escapeHtml(point.includes(":") ? point.split(":").slice(1).join(":").trim() : point)}</p>
+        </article>`,
+          )
+          .join("\n        ")}
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+export function renderTokensCss(mode: StudioDeckMode) {
+  const { width, height } = getDeckDimensionsForMode(mode);
+  const background =
+    mode === "pptx-safe"
+      ? "#faf8f1"
+      : "radial-gradient(circle at 20% 0%, rgba(215,255,114,.18), transparent 30%), #faf8f1";
+  const kickerBorder =
+    mode === "pptx-safe"
+      ? ""
+      : "border: 1px solid rgba(23,23,20,.2); border-radius: 999px;";
+  return `* { box-sizing: border-box; }
+html, body { margin: 0; width: ${width}px; height: ${height}px; overflow: hidden; }
+body { background: var(--studio-bg, ${background}); color: var(--studio-fg, #171714); font-family: Georgia, "Times New Roman", serif; }
+.slide { position: relative; width: ${width}px; height: ${height}px; padding: calc(58px * var(--studio-density-scale, 1)) calc(76px * var(--studio-density-scale, 1)) calc(64px * var(--studio-density-scale, 1)); }
+.masthead { display: flex; justify-content: space-between; border-bottom: 1px solid rgba(23,23,20,.18); padding-bottom: 18px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .12em; text-transform: uppercase; font-size: 16px; color: rgba(23,23,20,.55); }
+.content { height: calc(100% - 50px); display: flex; flex-direction: column; justify-content: center; gap: var(--studio-gap, 28px); }
+.kicker { width: fit-content; ${kickerBorder} padding: 8px 14px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 15px; letter-spacing: .16em; text-transform: uppercase; }
+h1 { max-width: 1240px; margin: 0; font-size: calc(118px * var(--studio-density-scale, 1)); line-height: .95; letter-spacing: -.055em; text-wrap: balance; }
+.cover h1 { max-width: 1500px; font-size: calc(150px * var(--studio-density-scale, 1)); }
+.lede { max-width: 980px; margin: 0; font-size: calc(30px * var(--studio-density-scale, 1)); line-height: 1.35; color: rgba(23,23,20,.72); text-wrap: pretty; }
+.process { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--studio-gap, 28px); max-width: 1440px; margin-top: 12px; }
+article { border-top: 1px solid rgba(23,23,20,.18); padding-top: 22px; }
+.eyebrow { margin: 0 0 14px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 14px; letter-spacing: .14em; text-transform: uppercase; color: rgba(23,23,20,.5); }
+h2 { margin: 0 0 12px; font-size: calc(36px * var(--studio-density-scale, 1)); letter-spacing: -.02em; }
+article p:last-child { margin: 0; max-width: 520px; font-size: calc(22px * var(--studio-density-scale, 1)); line-height: 1.55; color: rgba(23,23,20,.68); }
+`;
+}
+
+export function getDeckDimensionsForMode(mode: StudioDeckMode): DeckDimensions {
+  return mode === "pptx-safe"
+    ? { width: PPTX_SAFE_DECK_WIDTH, height: PPTX_SAFE_DECK_HEIGHT }
+    : { width: DECK_WIDTH, height: DECK_HEIGHT };
+}
+
+function slugify(value: string) {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 48) || "deck"
+  );
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/apps/studio/src/main/pi-service.ts
+++ b/apps/studio/src/main/pi-service.ts
@@ -80,8 +80,6 @@ let deckService: StudioDeckService | undefined;
 let chat: StudioChatController;
 /** Watches deck-plan.json in the current artifact and reconciles chat. */
 const deckPlanWatcher = new DeckPlanWatcher();
-/** Last model actually used to send a prompt (supports cursor + pi). */
-let lastPromptModelId: string | undefined;
 
 export function registerStudioIpc(window: BrowserWindow): void {
   mainWindow = window;
@@ -464,7 +462,6 @@ async function selectModel(input: StudioSelectModelInput): Promise<StudioAuthSta
 
   runtime.selectedModel = model;
   runtime.selectedModelId = input.modelId;
-  lastPromptModelId = input.modelId;
   if (runtime.session?.setModel) {
     await runtime.session.setModel(model);
   }
@@ -477,7 +474,7 @@ async function sendPrompt(input: StudioSendPromptInput): Promise<StudioConversat
   if (!content) return chat.getConversationSnapshot();
   await chat.ensureChatSessionsLoaded();
   if (input.modelId) {
-    lastPromptModelId = input.modelId;
+    await chat.rememberSubmittedModel(input.modelId);
   }
 
   const isCursorModel = isCursorModelId(input.modelId);
@@ -490,7 +487,7 @@ async function sendPrompt(input: StudioSendPromptInput): Promise<StudioConversat
   if (input.modelId && !isCursorModel) {
     await selectModel({ modelId: input.modelId });
   } else if (!input.modelId && runtime.selectedModelId) {
-    lastPromptModelId = runtime.selectedModelId;
+    await chat.rememberSubmittedModel(runtime.selectedModelId);
   }
 
   const userMessage: StudioMessage = {
@@ -674,6 +671,7 @@ async function newConversation(): Promise<StudioConversationSnapshot> {
   chat.messages = [];
   chat.status = "ready";
   chat.lastError = undefined;
+  chat.lastSubmittedModelId = undefined;
   chat.currentSessionId = createId("session");
   chat.currentArtifactId = createId("artifact");
   await getDeckService().ensureArtifactWorkspace(chat.currentArtifactId);
@@ -694,6 +692,7 @@ async function openChatSession(sessionId: string): Promise<StudioConversationSna
   if (!session) throw new Error("Chat session not found.");
   chat.currentSessionId = session.id;
   chat.currentArtifactId = session.artifactId;
+  chat.lastSubmittedModelId = session.lastSubmittedModelId;
   chat.messages = session.messages;
   chat.status = "ready";
   chat.lastError = undefined;
@@ -718,6 +717,7 @@ async function deleteChatSession(
     chat.messages = [];
     chat.status = "ready";
     chat.lastError = undefined;
+    chat.lastSubmittedModelId = undefined;
     chat.currentSessionId = createId("session");
     chat.currentArtifactId = createId("artifact");
     await getDeckService().ensureArtifactWorkspace(chat.currentArtifactId);
@@ -801,7 +801,7 @@ async function resumeAgentAfterPlanConfirm(): Promise<void> {
   // Find the model the user last picked. We re-use the same routing logic
   // as sendPrompt: cursor model → cursor runtime, else Pi runtime.
   const runtime = await getRuntime();
-  const modelId = lastPromptModelId ?? runtime.selectedModelId;
+  const modelId = chat.lastSubmittedModelId ?? runtime.selectedModelId;
   if (!modelId) return;
 
   const directive =

--- a/apps/studio/src/main/pi/types.ts
+++ b/apps/studio/src/main/pi/types.ts
@@ -89,4 +89,5 @@ export function createAssistantStreamState(): AssistantStreamState {
 export type StoredChatSession = StudioChatSessionSummary & {
   messages: StudioMessage[];
   manualTitle?: boolean;
+  lastSubmittedModelId?: string;
 };

--- a/apps/studio/src/main/studio-chat-controller.ts
+++ b/apps/studio/src/main/studio-chat-controller.ts
@@ -56,6 +56,7 @@ export class StudioChatController {
   status: StudioConversationSnapshot["status"] = "ready";
   lastError: string | undefined;
   currentArtifactId = createId("artifact");
+  lastSubmittedModelId: string | undefined;
   assistantStream: AssistantStreamState = createAssistantStreamState();
   chatSessions: StoredChatSession[] = [];
   sessionsLoaded = false;
@@ -401,6 +402,7 @@ export class StudioChatController {
       updatedAt: now,
       messages: this.messages,
       manualTitle: existing?.manualTitle,
+      lastSubmittedModelId: this.lastSubmittedModelId ?? existing?.lastSubmittedModelId,
     };
     this.chatSessions = [
       session,
@@ -412,6 +414,16 @@ export class StudioChatController {
   async persistChatSessions(): Promise<void> {
     await mkdir(getPiAgentDir(), { recursive: true });
     await writeFile(getChatSessionsPath(), JSON.stringify(this.chatSessions, null, 2), "utf8");
+  }
+
+  async rememberSubmittedModel(modelId: string): Promise<void> {
+    this.lastSubmittedModelId = modelId;
+    await this.ensureChatSessionsLoaded();
+    const existing = this.chatSessions.find((session) => session.id === this.currentSessionId);
+    if (!existing) return;
+    existing.lastSubmittedModelId = modelId;
+    existing.updatedAt = Date.now();
+    await this.persistChatSessions();
   }
 
   async listChatSessionSummaries(): Promise<StudioChatSessionSummary[]> {

--- a/apps/studio/src/main/studio-pptx-export.ts
+++ b/apps/studio/src/main/studio-pptx-export.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import pptxgen from "pptxgenjs";
 
 import type { StudioDeckProject } from "../shared/studio-api";
+import { waitForWebContentsVisualReady } from "./web-contents-ready";
 
 const PX_PER_IN = 96;
 const MIN_BOTTOM_MARGIN_IN = 0.35;
@@ -226,42 +227,7 @@ async function captureDeck(deck: StudioDeckProject, parentWindow?: BrowserWindow
  * surface as snapshot errors rather than silent hangs.
  */
 function waitForSlideLoad(win: BrowserWindow): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    const ceiling = setTimeout(finish, 2000);
-    const ready = () => {
-      win.webContents
-        .executeJavaScript(
-          `(async () => {
-            try { if (document.fonts && document.fonts.ready) { await document.fonts.ready; } } catch (_) {}
-            await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-            return true;
-          })()`,
-        )
-        .then(() => {
-          clearTimeout(ceiling);
-          finish();
-        })
-        .catch(() => {
-          clearTimeout(ceiling);
-          finish();
-        });
-    };
-    if (win.webContents.isLoading()) {
-      win.webContents.once("did-finish-load", ready);
-      win.webContents.once("did-fail-load", () => {
-        clearTimeout(ceiling);
-        finish();
-      });
-    } else {
-      ready();
-    }
-  });
+  return waitForWebContentsVisualReady(win.webContents, 2000);
 }
 
 function textOptions(position: Box, style: TextStyle) {

--- a/apps/studio/src/main/web-contents-ready.ts
+++ b/apps/studio/src/main/web-contents-ready.ts
@@ -1,0 +1,43 @@
+import type { WebContents } from "electron";
+
+export function waitForWebContentsVisualReady(
+  webContents: WebContents,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const ceiling = setTimeout(finish, timeoutMs);
+    const ready = () => {
+      webContents
+        .executeJavaScript(
+          `(async () => {
+            try { if (document.fonts && document.fonts.ready) { await document.fonts.ready; } } catch (_) {}
+            await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+            return true;
+          })()`,
+        )
+        .then(() => {
+          clearTimeout(ceiling);
+          finish();
+        })
+        .catch(() => {
+          clearTimeout(ceiling);
+          finish();
+        });
+    };
+    if (webContents.isLoading()) {
+      webContents.once("did-finish-load", ready);
+      webContents.once("did-fail-load", () => {
+        clearTimeout(ceiling);
+        finish();
+      });
+    } else {
+      ready();
+    }
+  });
+}

--- a/apps/studio/src/renderer/src/components/conversation/conversation-plan-card.tsx
+++ b/apps/studio/src/renderer/src/components/conversation/conversation-plan-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   IconCheck,
   IconExternalLink,
@@ -33,6 +33,7 @@ export function ChatPlanCard({
 }) {
   const { plan, superseded } = data;
   const confirmed = plan.status === "confirmed";
+  const [confirmedLatched, setConfirmedLatched] = useState(confirmed);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | undefined>();
   // Confirmed cards collapse by default (we already showed the user the plan
@@ -42,13 +43,18 @@ export function ChatPlanCard({
   // Q11: disable confirm during streaming so we don't yank the agent mid-turn.
   const disabledByStream = status === "streaming" || status === "submitted";
 
+  useEffect(() => {
+    if (confirmed) setConfirmedLatched(true);
+  }, [confirmed]);
+
   async function handleConfirm() {
-    if (busy || confirmed || superseded) return;
+    if (busy || confirmedLatched || superseded) return;
     setBusy(true);
     setError(undefined);
     try {
       // Look up the deck id from the artifact id — they're aliased in Studio.
       await window.api.confirmDeckPlan({ deckId: data.artifactId });
+      setConfirmedLatched(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not confirm plan.");
     } finally {
@@ -136,7 +142,7 @@ export function ChatPlanCard({
             <Button
               size="sm"
               className="h-7 text-xs"
-              disabled={busy || disabledByStream}
+              disabled={busy || confirmedLatched || disabledByStream}
               title={
                 disabledByStream ? "Waiting for agent to pause." : undefined
               }

--- a/apps/studio/src/renderer/src/components/deck-workspace.tsx
+++ b/apps/studio/src/renderer/src/components/deck-workspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   IconChevronRight,
   IconExternalLink,
@@ -88,6 +88,7 @@ export function DeckWorkspace({
   const [tweaksBusy, setTweaksBusy] = useState(false);
   const [templates, setTemplates] = useState<StudioDeckTemplateSummary[]>([]);
   const [creatingTemplateId, setCreatingTemplateId] = useState<string | undefined>();
+  const selectedDeckIdRef = useRef<string | undefined>(selectedDeckId);
 
   const selectedDeck = useMemo(
     () => decks.find((deck) => deck.id === selectedDeckId),
@@ -103,6 +104,10 @@ export function DeckWorkspace({
   const planPending = Boolean(selectedDeck?.plan && !planConfirmed);
   const hasSlides = Boolean(selectedDeck && selectedDeck.slides.length > 0);
   const exportsBlocked = !planConfirmed || !hasSlides;
+
+  useEffect(() => {
+    selectedDeckIdRef.current = selectedDeckId;
+  }, [selectedDeckId]);
 
   // Reset transient panel state when the user switches decks.
   useEffect(() => {
@@ -131,28 +136,34 @@ export function DeckWorkspace({
 
   async function handleExport(format: StudioDeckExportFormat) {
     if (!selectedDeck) return;
+    const requestDeckId = selectedDeck.id;
     setExportingFormat(format);
     setExportError(undefined);
     setExportMessage(undefined);
     setExportPath(undefined);
     try {
-      const result = await onExportDeck(selectedDeck.id, format);
+      const result = await onExportDeck(requestDeckId, format);
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setExportMessage(result.message);
       setExportPath(result.path);
     } catch (error) {
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setExportError(error instanceof Error ? error.message : "Export failed.");
     } finally {
-      setExportingFormat(undefined);
+      if (selectedDeckIdRef.current === requestDeckId) setExportingFormat(undefined);
     }
   }
 
   async function handleVerify() {
     if (!selectedDeck) return;
+    const requestDeckId = selectedDeck.id;
     setVerifying(true);
     try {
-      const result = await window.api.verifyDeck(selectedDeck.id);
+      const result = await window.api.verifyDeck(requestDeckId);
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setVerification(result);
     } catch (error) {
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setVerification({
         ok: false,
         issues: [
@@ -164,23 +175,26 @@ export function DeckWorkspace({
         checkedAt: Date.now(),
       });
     } finally {
-      setVerifying(false);
+      if (selectedDeckIdRef.current === requestDeckId) setVerifying(false);
     }
   }
 
   async function handleTweakChange(patch: Partial<StudioDeckTweaks>) {
     if (!selectedDeck) return;
+    const requestDeckId = selectedDeck.id;
     setTweaksBusy(true);
     try {
       const next: StudioDeckTweaks = { ...(selectedDeck.tweaks ?? {}), ...patch };
-      await window.api.applyDeckTweaks({ deckId: selectedDeck.id, tweaks: next });
+      await window.api.applyDeckTweaks({ deckId: requestDeckId, tweaks: next });
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setPreviewKey((key) => key + 1);
     } catch (error) {
+      if (selectedDeckIdRef.current !== requestDeckId) return;
       setExportError(
         error instanceof Error ? error.message : "Could not apply tweaks.",
       );
     } finally {
-      setTweaksBusy(false);
+      if (selectedDeckIdRef.current === requestDeckId) setTweaksBusy(false);
     }
   }
 
@@ -405,6 +419,7 @@ export function DeckWorkspace({
           <EmptyState
             templates={templates}
             creatingTemplateId={creatingTemplateId}
+            exportError={exportError}
             onCreate={handleCreateFromTemplate}
           />
         )}
@@ -445,7 +460,15 @@ function PlanStatusPill({
     );
   }
 
-  // Pending — clickable; nudges the user to the chat where the real card is.
+  // Pending — nudge the user to the chat where the real card is when possible.
+  if (!onShowChat) {
+    return (
+      <span className="mb-2 inline-flex items-center gap-1.5 self-start rounded-md border border-amber-400/40 bg-amber-50/40 px-2.5 py-1 text-[11px] text-amber-700 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-300">
+        Plan pending — confirm in chat
+      </span>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -669,10 +692,12 @@ function ExportBar({
 function EmptyState({
   templates,
   creatingTemplateId,
+  exportError,
   onCreate,
 }: {
   templates: StudioDeckTemplateSummary[];
   creatingTemplateId?: string;
+  exportError?: string;
   onCreate: (templateId: string) => void;
 }) {
   return (
@@ -720,6 +745,13 @@ function EmptyState({
             );
           })}
         </ul>
+      ) : null}
+      {exportError ? (
+        <Card className="w-full max-w-xl border-destructive/40 bg-destructive/10 text-left">
+          <CardContent className="whitespace-pre-wrap py-2 text-xs text-destructive">
+            {exportError}
+          </CardContent>
+        </Card>
       ) : null}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes PR review feedback for Studio deck planning/export flows, including watcher reliability, manifest/tweaks preservation, model reuse for auto-resume, stale async UI guards, and template deck rendering.
- Adds focused Studio main tests for generated deck notes, tweaks CSS opt-in, and PPTX-safe dimensions.

Closes #

## Surface(s) affected

- [ ] Web (`apps/web`)
- [ ] HTTP API (`apps/api`)
- [ ] CLI (`apps/cli`)
- [ ] SDK (`packages/sdk`)
- [ ] Agent skill (`skills/getdesign`)
- [ ] Shared package (`agent` / `tools` / `types` / `ui` / `config`)
- [ ] Convex (`convex/`)
- [ ] Repo tooling / docs
- [x] Studio desktop app (`apps/studio`)

## Breaking changes?

- [x] No
- [ ] Yes — migration notes:

## Screenshots / output samples

Automated verification completed:
- `bun test src/main`
- `bun run typecheck`
- `bun run build`

GUI walkthrough was attempted, but the computer-use handler was unavailable in this environment; Electron was launched under Xvfb for a runtime smoke check.

## Checklist

- [x] Conventional-commit title (e.g. `feat(skill): …`)
- [ ] `bun run lint` passes
- [x] `bun run typecheck` passes
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] If this changes the 9-section `design.md` contract, a maintainer has approved the schema change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab97746e-c0cc-4d9c-8b55-05bf8d19df32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab97746e-c0cc-4d9c-8b55-05bf8d19df32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

