### PR TITLE
feat(web): dashboard UI that runs the SDK live

### DIFF
--- a/apps/web/app/_components/nav.tsx
+++ b/apps/web/app/_components/nav.tsx
@@ -23,6 +23,7 @@ const LINKS: NavLink[] = [
     external: true,
   },
   { id: "design", label: "DESIGN", href: "/design", external: true },
+  { id: "dashboard", label: "DASHBOARD", href: "/dashboard", external: true },
   { id: "cta", label: "WAITLIST" },
 ];
 

--- a/apps/web/app/api/design/route.ts
+++ b/apps/web/app/api/design/route.ts
@@ -1,0 +1,122 @@
+import { streamDesign, type DesignStreamEvent } from "@getdesign/sdk";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+type DesignRequestBody = {
+  url?: unknown;
+  siteName?: unknown;
+  daytonaApiKey?: unknown;
+  openaiApiKey?: unknown;
+  visualRequirement?: unknown;
+};
+
+function stringField(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function jsonError(status: number, error: string, reason?: string): Response {
+  return new Response(JSON.stringify({ error, reason }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function encodeLine(event: DesignStreamEvent, encoder: TextEncoder): Uint8Array {
+  return encoder.encode(`${JSON.stringify(event)}\n`);
+}
+
+export async function POST(request: Request) {
+  let body: DesignRequestBody;
+  try {
+    body = (await request.json()) as DesignRequestBody;
+  } catch {
+    return jsonError(400, "invalid_json", "Request body must be JSON.");
+  }
+
+  const url = stringField(body.url);
+  if (!url || !isAbsoluteUrl(url)) {
+    return jsonError(
+      400,
+      "invalid_url",
+      "Provide an absolute http(s) URL in `url`.",
+    );
+  }
+
+  const daytonaApiKey = stringField(body.daytonaApiKey);
+  const openaiApiKey = stringField(body.openaiApiKey);
+  if (!daytonaApiKey || !openaiApiKey) {
+    return jsonError(
+      400,
+      "missing_credentials",
+      "Provide your own Daytona and OpenAI API keys to run a design.",
+    );
+  }
+
+  const siteName = stringField(body.siteName);
+  const visualRequirement =
+    stringField(body.visualRequirement) === "text_only_fallback"
+      ? "text_only_fallback"
+      : "require";
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const safeEnqueue = (event: DesignStreamEvent) => {
+        try {
+          controller.enqueue(encodeLine(event, encoder));
+        } catch {
+          // Client disconnected; nothing to do.
+        }
+      };
+
+      try {
+        for await (const event of streamDesign(url, {
+          siteName,
+          credentials: { daytonaApiKey, openaiApiKey },
+          visualRequirement,
+        })) {
+          safeEnqueue(event);
+        }
+      } catch (err) {
+        safeEnqueue({
+          type: "error",
+          error: {
+            error: "internal_error",
+            reason:
+              err instanceof Error
+                ? err.message
+                : "Unknown error while running design.",
+          },
+        });
+      } finally {
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+      "cache-control": "no-store",
+      "x-accel-buffering": "no",
+    },
+  });
+}

--- a/apps/web/app/dashboard/_components/dashboard-header.tsx
+++ b/apps/web/app/dashboard/_components/dashboard-header.tsx
@@ -1,0 +1,22 @@
+export function DashboardHeader() {
+  return (
+    <section className="dashed-bottom px-6 py-16 sm:py-20">
+      <div className="flex items-center gap-2 text-[12px] text-muted">
+        <span className="text-[var(--accent)]">✦</span>
+        Dashboard
+      </div>
+
+      <h1 className="display-hero mt-6 max-w-[820px]">
+        Generate a <span className="text-foreground">design.md</span>
+        <br />
+        from any URL<span className="text-[var(--accent)]">.</span>
+      </h1>
+
+      <p className="mt-6 max-w-[560px] text-[14.5px] leading-relaxed text-muted">
+        Paste a URL and your own Daytona and OpenAI keys. The agent renders the
+        site in a real browser, extracts tokens and components, and returns a
+        production-grade <span className="text-foreground">design.md</span>.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/app/dashboard/_components/dashboard-runner.tsx
+++ b/apps/web/app/dashboard/_components/dashboard-runner.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { DesignStreamEvent } from "@getdesign/sdk";
+
+import { PhaseList } from "./phase-list";
+import { ResultViewer } from "./result-viewer";
+import type {
+  DashboardResult,
+  DashboardStatus,
+  PhaseId,
+  PhaseState,
+} from "./types";
+
+const INITIAL_PHASES: Record<PhaseId, PhaseState> = {
+  crawl: "pending",
+  capture: "pending",
+  visual: "pending",
+  describe: "pending",
+  extract: "pending",
+  synthesize: "pending",
+  render: "pending",
+};
+
+const KEY_STORAGE = {
+  daytona: "getdesign.dashboard.daytonaKey",
+  openai: "getdesign.dashboard.openaiKey",
+} as const;
+
+type FormState = {
+  url: string;
+  siteName: string;
+  daytonaApiKey: string;
+  openaiApiKey: string;
+  rememberKeys: boolean;
+};
+
+const INITIAL_FORM: FormState = {
+  url: "",
+  siteName: "",
+  daytonaApiKey: "",
+  openaiApiKey: "",
+  rememberKeys: false,
+};
+
+export function DashboardRunner() {
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+  const [status, setStatus] = useState<DashboardStatus>("idle");
+  const [phases, setPhases] = useState<Record<PhaseId, PhaseState>>(
+    INITIAL_PHASES,
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [result, setResult] = useState<DashboardResult | null>(null);
+  const [elapsed, setElapsed] = useState<number>(0);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const startedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const daytona = window.localStorage.getItem(KEY_STORAGE.daytona) ?? "";
+      const openai = window.localStorage.getItem(KEY_STORAGE.openai) ?? "";
+      if (daytona || openai) {
+        setForm((prev) => ({
+          ...prev,
+          daytonaApiKey: daytona,
+          openaiApiKey: openai,
+          rememberKeys: Boolean(daytona || openai),
+        }));
+      }
+    } catch {
+      // Local storage may be unavailable; ignore.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== "running") return;
+    const interval = setInterval(() => {
+      if (startedAtRef.current != null) {
+        setElapsed(Date.now() - startedAtRef.current);
+      }
+    }, 250);
+    return () => clearInterval(interval);
+  }, [status]);
+
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    [],
+  );
+
+  const handleField = useCallback(
+    <K extends keyof FormState>(key: K, value: FormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const persistKeys = useCallback((next: FormState) => {
+    if (typeof window === "undefined") return;
+    try {
+      if (next.rememberKeys) {
+        window.localStorage.setItem(KEY_STORAGE.daytona, next.daytonaApiKey);
+        window.localStorage.setItem(KEY_STORAGE.openai, next.openaiApiKey);
+      } else {
+        window.localStorage.removeItem(KEY_STORAGE.daytona);
+        window.localStorage.removeItem(KEY_STORAGE.openai);
+      }
+    } catch {
+      // Ignore.
+    }
+  }, []);
+
+  const applyEvent = useCallback((event: DesignStreamEvent) => {
+    if (event.type === "result") {
+      setResult(event.result);
+      setStatus("done");
+      setPhases((prev) => {
+        const next = { ...prev };
+        for (const key of Object.keys(next) as PhaseId[]) {
+          if (next[key] !== "error") next[key] = "ok";
+        }
+        return next;
+      });
+      return;
+    }
+
+    if (event.type === "error") {
+      setStatus("error");
+      setErrorMessage(
+        event.error.reason ?? event.error.error ?? "Run failed.",
+      );
+      setPhases((prev) => {
+        const next = { ...prev };
+        let markedError = false;
+        for (const key of Object.keys(next) as PhaseId[]) {
+          if (next[key] === "running") {
+            next[key] = "error";
+            markedError = true;
+          }
+        }
+        if (!markedError) {
+          for (const key of Object.keys(next) as PhaseId[]) {
+            if (next[key] === "pending") {
+              next[key] = "error";
+              markedError = true;
+              break;
+            }
+          }
+        }
+        return next;
+      });
+      return;
+    }
+
+    if (event.type !== "progress") return;
+
+    const phaseId = event.event.phase as PhaseId;
+    setPhases((prev) => {
+      if (!(phaseId in prev)) return prev;
+      const next = { ...prev };
+      if (event.event.status === "ok") {
+        next[phaseId] = "ok";
+      } else if (event.event.status === "start") {
+        next[phaseId] = "running";
+      } else {
+        if (next[phaseId] === "pending") next[phaseId] = "running";
+      }
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setStatus("idle");
+    setPhases(INITIAL_PHASES);
+    setErrorMessage(null);
+    setResult(null);
+    setElapsed(0);
+    startedAtRef.current = null;
+  }, []);
+
+  const onSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (status === "running") return;
+
+      const url = form.url.trim();
+      const daytona = form.daytonaApiKey.trim();
+      const openai = form.openaiApiKey.trim();
+
+      if (!url) {
+        setStatus("error");
+        setErrorMessage("Enter a URL to design.");
+        return;
+      }
+      if (!daytona || !openai) {
+        setStatus("error");
+        setErrorMessage("Provide both Daytona and OpenAI API keys.");
+        return;
+      }
+
+      persistKeys(form);
+
+      setStatus("running");
+      setPhases(INITIAL_PHASES);
+      setErrorMessage(null);
+      setResult(null);
+      setElapsed(0);
+      startedAtRef.current = Date.now();
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const response = await fetch("/api/design", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          signal: controller.signal,
+          body: JSON.stringify({
+            url,
+            siteName: form.siteName.trim() || undefined,
+            daytonaApiKey: daytona,
+            openaiApiKey: openai,
+          }),
+        });
+
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => ({}))) as {
+            reason?: string;
+            error?: string;
+          };
+          throw new Error(
+            payload.reason ?? payload.error ?? `Request failed (${response.status}).`,
+          );
+        }
+
+        const body = response.body;
+        if (!body) throw new Error("Empty response from server.");
+
+        const reader = body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let newlineIndex = buffer.indexOf("\n");
+          while (newlineIndex !== -1) {
+            const line = buffer.slice(0, newlineIndex).trim();
+            buffer = buffer.slice(newlineIndex + 1);
+            if (line) {
+              try {
+                const event = JSON.parse(line) as DesignStreamEvent;
+                applyEvent(event);
+              } catch {
+                // Ignore malformed lines.
+              }
+            }
+            newlineIndex = buffer.indexOf("\n");
+          }
+        }
+
+        const tail = buffer.trim();
+        if (tail) {
+          try {
+            applyEvent(JSON.parse(tail) as DesignStreamEvent);
+          } catch {
+            // Ignore.
+          }
+        }
+      } catch (err) {
+        if ((err as { name?: string }).name === "AbortError") return;
+        setStatus("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Run failed.",
+        );
+        setPhases((prev) => {
+          const next = { ...prev };
+          for (const key of Object.keys(next) as PhaseId[]) {
+            if (next[key] === "running") next[key] = "error";
+          }
+          return next;
+        });
+      } finally {
+        abortRef.current = null;
+      }
+    },
+    [applyEvent, form, persistKeys, status],
+  );
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (status === "running") {
+      setStatus("error");
+      setErrorMessage("Run cancelled.");
+      setPhases((prev) => {
+        const next = { ...prev };
+        for (const key of Object.keys(next) as PhaseId[]) {
+          if (next[key] === "running") next[key] = "error";
+        }
+        return next;
+      });
+    }
+  }, [status]);
+
+  const isRunning = status === "running";
+
+  return (
+    <section className="px-6 pb-24 pt-10">
+      <div className="grid items-start gap-6 lg:grid-cols-[1fr_1fr]">
+        <form
+          onSubmit={onSubmit}
+          className="rounded-xl border border-[var(--border)] bg-[var(--surface-100)] p-5"
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <div className="text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
+              New run
+            </div>
+            <div className="font-mono text-[10.5px] text-[var(--subtle)]">
+              getDesign
+            </div>
+          </div>
+
+          <Field
+            id="url"
+            label="URL"
+            helper="Public landing page rendered in a real browser."
+          >
+            <div className="flex items-stretch rounded-md border border-[var(--border-strong)] bg-[var(--background)]">
+              <span className="flex items-center pl-3 font-mono text-[12px] text-[var(--accent)]">
+                {">"}
+              </span>
+              <input
+                id="url"
+                type="url"
+                inputMode="url"
+                autoComplete="url"
+                placeholder="https://linear.app"
+                spellCheck={false}
+                value={form.url}
+                onChange={(e) => handleField("url", e.target.value)}
+                disabled={isRunning}
+                required
+                className="h-10 w-full bg-transparent px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none disabled:opacity-60"
+              />
+            </div>
+          </Field>
+
+          <Field
+            id="siteName"
+            label="Site name"
+            helper="Optional. Defaults to the hostname."
+          >
+            <input
+              id="siteName"
+              type="text"
+              placeholder="Linear"
+              value={form.siteName}
+              onChange={(e) => handleField("siteName", e.target.value)}
+              disabled={isRunning}
+              className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)] disabled:opacity-60"
+            />
+          </Field>
+
+          <div className="my-5 dashed-top h-px" />
+
+          <div className="mb-3 flex items-center justify-between text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
+            <span>BYOK credentials</span>
+            <span className="font-mono normal-case tracking-normal text-[var(--subtle)]">
+              never persisted server-side
+            </span>
+          </div>
+
+          <Field
+            id="daytonaApiKey"
+            label="Daytona API key"
+            helper={
+              <>
+                Used to launch the capture sandbox. Get one at{" "}
+                <a
+                  href="https://app.daytona.io/dashboard/keys"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-foreground underline-offset-4 hover:underline"
+                >
+                  app.daytona.io
+                </a>
+                .
+              </>
+            }
+          >
+            <input
+              id="daytonaApiKey"
+              type="password"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="dt_live_..."
+              value={form.daytonaApiKey}
+              onChange={(e) => handleField("daytonaApiKey", e.target.value)}
+              disabled={isRunning}
+              required
+              className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)] disabled:opacity-60"
+            />
+          </Field>
+
+          <Field
+            id="openaiApiKey"
+            label="OpenAI API key"
+            helper={
+              <>
+                Used for visual description and synthesis. Get one at{" "}
+                <a
+                  href="https://platform.openai.com/api-keys"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-foreground underline-offset-4 hover:underline"
+                >
+                  platform.openai.com
+                </a>
+                .
+              </>
+            }
+          >
+            <input
+              id="openaiApiKey"
+              type="password"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="sk-..."
+              value={form.openaiApiKey}
+              onChange={(e) => handleField("openaiApiKey", e.target.value)}
+              disabled={isRunning}
+              required
+              className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)] disabled:opacity-60"
+            />
+          </Field>
+
+          <label className="mt-1 flex items-center gap-2 text-[11.5px] text-[var(--subtle)]">
+            <input
+              type="checkbox"
+              checked={form.rememberKeys}
+              onChange={(e) => handleField("rememberKeys", e.target.checked)}
+              disabled={isRunning}
+              className="h-3.5 w-3.5 accent-[var(--accent)]"
+            />
+            Remember keys in this browser
+          </label>
+
+          <div className="mt-6 flex items-center gap-2">
+            {isRunning ? (
+              <button
+                type="button"
+                onClick={cancel}
+                className="btn-ghost inline-flex h-9 items-center rounded-md px-3 text-[12.5px]"
+              >
+                Cancel
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={reset}
+                disabled={status === "idle"}
+                className="btn-ghost inline-flex h-9 items-center rounded-md px-3 text-[12.5px] disabled:opacity-40"
+              >
+                Reset
+              </button>
+            )}
+            <button
+              type="submit"
+              disabled={isRunning}
+              className="btn-accent inline-flex h-9 items-center rounded-md px-4 text-[12.5px] font-medium disabled:opacity-60"
+            >
+              {isRunning ? "Generating…" : "Generate design.md"}
+            </button>
+          </div>
+        </form>
+
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-100)]">
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-2.5">
+            <div className="text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
+              Progress
+            </div>
+            <div className="font-mono text-[10.5px] text-[var(--subtle)]">
+              {status === "idle" && "idle"}
+              {status === "running" && `${formatElapsed(elapsed)}`}
+              {status === "done" && `done · ${formatElapsed(elapsed)}`}
+              {status === "error" && "error"}
+            </div>
+          </div>
+          <PhaseList phases={phases} errorMessage={errorMessage} />
+        </div>
+      </div>
+
+      <div className="mt-8">
+        {result ? (
+          <ResultViewer result={result} />
+        ) : (
+          <EmptyResult status={status} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyResult({ status }: { status: DashboardStatus }) {
+  const label =
+    status === "running"
+      ? "Streaming events. The design.md will appear here when synthesis finishes."
+      : status === "error"
+        ? "Run did not finish. Fix the error above and try again."
+        : "Run a URL to see the generated design.md here.";
+
+  return (
+    <div className="dashed-frame rounded-xl bg-[var(--surface-100)] px-6 py-16 text-center">
+      <div className="mx-auto max-w-md text-[13px] text-muted">{label}</div>
+    </div>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds - m * 60);
+  return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
+type FieldProps = {
+  id: string;
+  label: string;
+  helper?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+function Field({ id, label, helper, children }: FieldProps) {
+  return (
+    <div className="mb-4">
+      <label
+        htmlFor={id}
+        className="mb-1.5 block text-[11px] uppercase tracking-[0.16em] text-[var(--subtle)]"
+      >
+        {label}
+      </label>
+      {children}
+      {helper ? (
+        <div className="mt-1.5 text-[11.5px] text-[var(--subtle)]">
+          {helper}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/_components/phase-list.tsx
+++ b/apps/web/app/dashboard/_components/phase-list.tsx
@@ -1,0 +1,94 @@
+import type { PhaseId, PhaseState } from "./types";
+
+const PHASES: { id: PhaseId; label: string; detail: string }[] = [
+  { id: "crawl", label: "Crawl", detail: "Read stylesheets and DOM" },
+  { id: "capture", label: "Capture", detail: "Full landing page screenshot" },
+  { id: "visual", label: "Visual", detail: "Tile sequence ready" },
+  { id: "describe", label: "Describe", detail: "Long-form visual walkthrough" },
+  { id: "extract", label: "Extract", detail: "Cluster CSS tokens" },
+  { id: "synthesize", label: "Synthesize", detail: "Design doc from agent" },
+  { id: "render", label: "Render", detail: "Write design.md" },
+];
+
+type PhaseListProps = {
+  phases: Record<PhaseId, PhaseState>;
+  errorMessage: string | null;
+};
+
+export function PhaseList({ phases, errorMessage }: PhaseListProps) {
+  return (
+    <ol className="space-y-px">
+      {PHASES.map((phase) => {
+        const state = phases[phase.id] ?? "pending";
+
+        return (
+          <li
+            key={phase.id}
+            className="flex items-center gap-3 border-t border-[var(--border)] px-4 py-2.5 first:border-t-0"
+          >
+            <PhaseIndicator state={state} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline justify-between gap-3">
+                <span
+                  className={
+                    state === "pending"
+                      ? "text-[13px] text-[var(--subtle)]"
+                      : "text-[13px] text-foreground"
+                  }
+                >
+                  {phase.label}
+                </span>
+                <span className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-[var(--subtle)]">
+                  {state === "pending"
+                    ? "—"
+                    : state === "running"
+                      ? "running"
+                      : state === "ok"
+                        ? "ok"
+                        : "error"}
+                </span>
+              </div>
+              <div className="text-[11.5px] text-[var(--subtle)]">
+                {phase.detail}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+      {errorMessage ? (
+        <li className="mt-3 rounded-md border border-[var(--border-strong)] bg-[var(--surface-200)] px-4 py-3 text-[12.5px] text-[var(--danger)]">
+          {errorMessage}
+        </li>
+      ) : null}
+    </ol>
+  );
+}
+
+function PhaseIndicator({ state }: { state: PhaseState }) {
+  if (state === "ok") {
+    return (
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-[var(--border-strong)] bg-[var(--surface-200)] text-[10px] text-[var(--accent)]">
+        ✓
+      </span>
+    );
+  }
+  if (state === "running") {
+    return (
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-[var(--border-strong)] bg-[var(--surface-200)]">
+        <span className="pulse-dot h-1.5 w-1.5 rounded-full bg-[var(--accent)]" />
+      </span>
+    );
+  }
+  if (state === "error") {
+    return (
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-[var(--border-strong)] bg-[var(--surface-200)] text-[10px] text-[var(--danger)]">
+        ×
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-dashed border-[var(--border-strong)]">
+      <span className="h-1 w-1 rounded-full bg-[var(--subtle)]" />
+    </span>
+  );
+}

--- a/apps/web/app/dashboard/_components/result-viewer.tsx
+++ b/apps/web/app/dashboard/_components/result-viewer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { DashboardResult } from "./types";
+
+type ResultViewerProps = {
+  result: DashboardResult;
+};
+
+function deriveHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "site";
+  }
+}
+
+function safeFilename(host: string): string {
+  return host.replace(/[^a-z0-9.-]+/gi, "-").toLowerCase() || "site";
+}
+
+export function ResultViewer({ result }: ResultViewerProps) {
+  const host = useMemo(() => deriveHostname(result.url), [result.url]);
+  const filename = useMemo(() => `${safeFilename(host)}.design.md`, [host]);
+
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimer.current) {
+        clearTimeout(copyTimer.current);
+      }
+    };
+  }, []);
+
+  const downloadHref = useMemo(() => {
+    if (typeof window === "undefined") return undefined;
+    const blob = new Blob([result.markdown], {
+      type: "text/markdown;charset=utf-8",
+    });
+    return URL.createObjectURL(blob);
+  }, [result.markdown]);
+
+  useEffect(() => {
+    if (!downloadHref) return;
+    return () => URL.revokeObjectURL(downloadHref);
+  }, [downloadHref]);
+
+  async function onCopy() {
+    try {
+      await navigator.clipboard.writeText(result.markdown);
+      setCopied(true);
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // Clipboard not available; ignore.
+    }
+  }
+
+  const bytes = useMemo(
+    () => new TextEncoder().encode(result.markdown).byteLength,
+    [result.markdown],
+  );
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-100)]">
+      <div className="flex items-center gap-3 border-b border-[var(--border)] bg-[var(--surface-200)] px-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f56]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#ffbd2e]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#27c93f]" />
+        </div>
+        <div className="flex-1 truncate rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1 text-center font-mono text-[11.5px] text-[var(--subtle)]">
+          {filename}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCopy}
+            className="btn-ghost inline-flex h-7 items-center rounded-md px-2.5 text-[11.5px]"
+          >
+            {copied ? "copied ✓" : "copy"}
+          </button>
+          <a
+            href={downloadHref}
+            download={filename}
+            className="btn-accent inline-flex h-7 items-center rounded-md px-2.5 text-[11.5px] font-medium"
+          >
+            download
+          </a>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 border-b border-[var(--border)] px-4 py-2 font-mono text-[10.5px] uppercase tracking-[0.16em] text-[var(--subtle)]">
+        <span>{result.mode === "visual" ? "visual" : "text-only"}</span>
+        <span>·</span>
+        <span>{result.tiles} tiles</span>
+        <span>·</span>
+        <span>{formatBytes(bytes)}</span>
+        <span className="ml-auto truncate text-[10.5px] normal-case tracking-normal text-[var(--subtle)]">
+          {result.url}
+        </span>
+      </div>
+
+      <pre className="code-scroll max-h-[640px] overflow-auto bg-[var(--surface-100)] px-5 py-5 font-mono text-[12.5px] leading-relaxed text-foreground">
+        <code>{result.markdown}</code>
+      </pre>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/apps/web/app/dashboard/_components/types.ts
+++ b/apps/web/app/dashboard/_components/types.ts
@@ -1,0 +1,19 @@
+import type { DesignStreamEvent } from "@getdesign/sdk";
+
+export type PhaseId =
+  | "crawl"
+  | "capture"
+  | "visual"
+  | "describe"
+  | "extract"
+  | "synthesize"
+  | "render";
+
+export type PhaseState = "pending" | "running" | "ok" | "error";
+
+export type DashboardStatus = "idle" | "running" | "done" | "error";
+
+export type DashboardResult = Extract<
+  DesignStreamEvent,
+  { type: "result" }
+>["result"];

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+
+import { MarketingShell } from "../_components/marketing-shell";
+import { SiteFooter } from "../_components/site-footer";
+import { DashboardHeader } from "./_components/dashboard-header";
+import { DashboardRunner } from "./_components/dashboard-runner";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description:
+    "Generate a production-grade design.md from any URL. Paste a URL, bring your own Daytona and OpenAI keys, and download the result.",
+  alternates: { canonical: "/dashboard" },
+  robots: { index: false, follow: false },
+  openGraph: {
+    title: "Dashboard · getdesign",
+    description:
+      "Run the agent live. Paste a URL, watch progress, download the generated design.md.",
+    url: "/dashboard",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Dashboard · getdesign",
+    description:
+      "Run the agent live. Paste a URL, watch progress, download the generated design.md.",
+  },
+};
+
+export default function DashboardPage() {
+  return (
+    <MarketingShell footer={<SiteFooter />}>
+      <DashboardHeader />
+      <DashboardRunner />
+    </MarketingShell>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@getdesign/sdk": "workspace:*",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "convex": "^1.35.1",
     "next": "16.2.4",

--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@getdesign/sdk": "workspace:*",
         "@icons-pack/react-simple-icons": "^13.13.0",
         "convex": "^1.35.1",
         "next": "16.2.4",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a real `/dashboard` to `apps/web` that drives the public `@getdesign/sdk` end-to-end:

- Paste a URL, bring your own Daytona + OpenAI keys, hit **Generate**.
- The browser POSTs to a new `/api/design` route, which calls `streamDesign` from the SDK and pipes events back as newline-delimited JSON.
- The UI shows live per-phase progress (`crawl → capture → visual → describe → extract → synthesize → render`), elapsed time, and surfaces errors inline.
- When the run completes, the generated `design.md` renders in a code surface with **Copy** and **Download** actions (download produces `<host>.design.md`).
- Runs are intentionally **not persisted** — this is the live dashboard, not a runs database.

## Walkthrough

[dashboard_run_demo.mp4](https://cursor.com/agents/bc-5bb58158-3f65-438e-98e8-1d363a5bba70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_run_demo.mp4)
Form fill → submit → live per-phase progress → SDK-sourced error surfaced inline (`Response from https://linear.app exceeded 1000000 bytes` is the agent crawler's own size guard, confirming the SDK is actually invoked).

[Dashboard idle state](https://cursor.com/agents/bc-5bb58158-3f65-438e-98e8-1d363a5bba70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_idle.png)
Idle state with empty form, pending progress, and empty result placeholder.

[Dashboard success state with design.md viewer](https://cursor.com/agents/bc-5bb58158-3f65-438e-98e8-1d363a5bba70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_success.png)
Success state showing all phases OK and the generated `design.md` with copy + download. (Captured with a temporary local `DASHBOARD_DEMO=1` env flag that was reverted before commit; not present in the merged code.)

[Dashboard error state](https://cursor.com/agents/bc-5bb58158-3f65-438e-98e8-1d363a5bba70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_error.png)
Error state when the SDK fails mid-run.

## Files

- `apps/web/app/api/design/route.ts` — Node runtime POST handler; validates input, drives `streamDesign`, streams `application/x-ndjson`.
- `apps/web/app/dashboard/page.tsx` — Marketing-shell page, `robots: noindex`.
- `apps/web/app/dashboard/_components/dashboard-header.tsx`
- `apps/web/app/dashboard/_components/dashboard-runner.tsx` — client form + stream consumer.
- `apps/web/app/dashboard/_components/phase-list.tsx` — phase indicators.
- `apps/web/app/dashboard/_components/result-viewer.tsx` — `design.md` viewer + copy/download.
- `apps/web/app/dashboard/_components/types.ts`
- `apps/web/app/_components/nav.tsx` — adds `DASHBOARD` link.
- `apps/web/package.json`, `bun.lock` — adds `@getdesign/sdk` as `workspace:*`.

## Design notes

- Uses the existing dark, dashed-frame styling so the dashboard reads as part of the same product as `/` and `/design`.
- Credentials are POSTed in a JSON body (never in a URL query) and can optionally be remembered in `localStorage` for the current browser only. The server never persists them.
- Stream protocol: `application/x-ndjson`, one `DesignStreamEvent` JSON per line; the client parses on newlines and updates phase state, the final result, or surfaces an error.
- `maxDuration = 300` and `runtime = "nodejs"` on the route so the agent has room to capture + synthesize.

## Verification

- ✅ `bun run typecheck` (in `apps/web`)
- ✅ `bun run build` (in `apps/web`) — new `/dashboard` static route and dynamic `/api/design` function show up in route table
- ✅ API rejects invalid URL and missing credentials with 400
- ✅ End-to-end stream test against a live URL: the SDK is invoked and emits the error event back through the stream into the UI (see demo video)
- ✅ Mocked success path renders the `design.md` viewer with copy + download (see success screenshot)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bb58158-3f65-438e-98e8-1d363a5bba70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bb58158-3f65-438e-98e8-1d363a5bba70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

