### PR TITLE
feat(web): store per-user Daytona/OpenAI keys in WorkOS Vault

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,6 +16,41 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Dashboard credentials (Daytona + OpenAI)
+
+The `/dashboard` runs the agent with a Daytona key (capture sandbox) and an
+OpenAI key (synthesis). The API route at `app/api/design/route.ts` resolves these
+per run, in priority order:
+
+1. **Request body** — keys typed into the dashboard form (BYOK, never persisted server-side).
+2. **WorkOS Vault** — the signed-in user's keys, saved once at `/dashboard/settings`.
+3. **Environment variables** — `DAYTONA_API_KEY` / `OPENAI_API_KEY`, the local-dev fallback.
+
+### Local development
+
+No account needed. Set the keys in `apps/web/.env.local` and run as usual:
+
+```bash
+DAYTONA_API_KEY=dt_live_...
+OPENAI_API_KEY=sk-...
+```
+
+### Per-user storage with WorkOS Vault
+
+To let users sign in and store their own keys, configure WorkOS AuthKit + Vault:
+
+```bash
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+WORKOS_COOKIE_PASSWORD=...        # >= 32 chars, e.g. `openssl rand -base64 32`
+NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
+```
+
+When these are set, the app enables sign-in (`/login`, `/callback`) and the
+`/dashboard/settings` page, where each user stores their Daytona and OpenAI keys
+encrypted in WorkOS Vault (scoped to their user id). When they are **not** set,
+the app stays in "local mode": no auth, env-var keys only, BYOK form still works.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/apps/web/app/_lib/auth.ts
+++ b/apps/web/app/_lib/auth.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import { isWorkOSConfigured } from "./workos";
+
+export type SessionUser = {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+/**
+ * Resolve the signed-in WorkOS user for the current request, or `null` when no
+ * session exists or WorkOS is not configured (local mode).
+ */
+export async function getCurrentUser(): Promise<SessionUser | null> {
+  if (!isWorkOSConfigured()) return null;
+
+  const { withAuth } = await import("@workos-inc/authkit-nextjs");
+  const { user } = await withAuth();
+  if (!user) return null;
+
+  return {
+    id: user.id,
+    email: user.email,
+    firstName: user.firstName ?? null,
+    lastName: user.lastName ?? null,
+  };
+}

--- a/apps/web/app/_lib/credentials-resolver.test.ts
+++ b/apps/web/app/_lib/credentials-resolver.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveCredentials } from "./credentials-resolver";
+
+describe("resolveCredentials", () => {
+  test("prefers request keys over vault and env", () => {
+    const result = resolveCredentials({
+      request: { daytonaApiKey: "dt_request", openaiApiKey: "sk_request" },
+      vault: { daytonaApiKey: "dt_vault", openaiApiKey: "sk_vault" },
+      env: { daytonaApiKey: "dt_env", openaiApiKey: "sk_env" },
+    });
+
+    expect(result.credentials).toEqual({
+      daytonaApiKey: "dt_request",
+      openaiApiKey: "sk_request",
+    });
+    expect(result.origin).toEqual({
+      daytonaApiKey: "request",
+      openaiApiKey: "request",
+    });
+    expect(result.missing).toEqual([]);
+  });
+
+  test("falls back to vault when request keys are absent", () => {
+    const result = resolveCredentials({
+      vault: { daytonaApiKey: "dt_vault", openaiApiKey: "sk_vault" },
+      env: { daytonaApiKey: "dt_env", openaiApiKey: "sk_env" },
+    });
+
+    expect(result.credentials).toEqual({
+      daytonaApiKey: "dt_vault",
+      openaiApiKey: "sk_vault",
+    });
+    expect(result.origin.daytonaApiKey).toBe("vault");
+    expect(result.origin.openaiApiKey).toBe("vault");
+  });
+
+  test("falls back to env as the last resort (local dev)", () => {
+    const result = resolveCredentials({
+      env: { daytonaApiKey: "dt_env", openaiApiKey: "sk_env" },
+    });
+
+    expect(result.credentials).toEqual({
+      daytonaApiKey: "dt_env",
+      openaiApiKey: "sk_env",
+    });
+    expect(result.origin.daytonaApiKey).toBe("env");
+    expect(result.missing).toEqual([]);
+  });
+
+  test("resolves each key independently across sources", () => {
+    const result = resolveCredentials({
+      request: { daytonaApiKey: "dt_request" },
+      vault: { openaiApiKey: "sk_vault" },
+      env: { openaiApiKey: "sk_env" },
+    });
+
+    expect(result.credentials).toEqual({
+      daytonaApiKey: "dt_request",
+      openaiApiKey: "sk_vault",
+    });
+    expect(result.origin.daytonaApiKey).toBe("request");
+    expect(result.origin.openaiApiKey).toBe("vault");
+  });
+
+  test("treats blank / whitespace values as absent", () => {
+    const result = resolveCredentials({
+      request: { daytonaApiKey: "   ", openaiApiKey: "" },
+      vault: { daytonaApiKey: "dt_vault" },
+    });
+
+    expect(result.credentials.daytonaApiKey).toBe("dt_vault");
+    expect(result.credentials.openaiApiKey).toBeUndefined();
+    expect(result.missing).toEqual(["openaiApiKey"]);
+  });
+
+  test("reports all missing keys when nothing resolves", () => {
+    const result = resolveCredentials({});
+    expect(result.credentials).toEqual({});
+    expect(result.missing).toEqual(["daytonaApiKey", "openaiApiKey"]);
+  });
+});

--- a/apps/web/app/_lib/credentials-resolver.ts
+++ b/apps/web/app/_lib/credentials-resolver.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure credential resolution logic shared by the design API route.
+ *
+ * Lives in its own module (no `server-only`, no I/O) so the priority rules can
+ * be unit tested without a WorkOS account or a running server.
+ */
+
+export type ResolvedCredentials = {
+  daytonaApiKey?: string;
+  openaiApiKey?: string;
+};
+
+/** Where a resolved key came from, in priority order. */
+export type CredentialSource = "request" | "vault" | "env";
+
+export type CredentialSources = {
+  /** Request-scoped BYOK keys sent in the API body. Highest priority. */
+  request?: ResolvedCredentials;
+  /** Per-user keys read from WorkOS Vault. Used when the user is signed in. */
+  vault?: ResolvedCredentials;
+  /** Process environment keys. Local-development fallback, lowest priority. */
+  env?: ResolvedCredentials;
+};
+
+export type CredentialResolution = {
+  credentials: ResolvedCredentials;
+  origin: {
+    daytonaApiKey?: CredentialSource;
+    openaiApiKey?: CredentialSource;
+  };
+  /** Keys that could not be resolved from any source. */
+  missing: Array<"daytonaApiKey" | "openaiApiKey">;
+};
+
+function clean(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve each credential by priority: request (BYOK) > vault (per-user) > env.
+ *
+ * Each key is resolved independently, so a user can, for example, store their
+ * OpenAI key in Vault while overriding the Daytona key for a single run.
+ */
+export function resolveCredentials(
+  sources: CredentialSources,
+): CredentialResolution {
+  const order: Array<[CredentialSource, ResolvedCredentials | undefined]> = [
+    ["request", sources.request],
+    ["vault", sources.vault],
+    ["env", sources.env],
+  ];
+
+  const credentials: ResolvedCredentials = {};
+  const origin: CredentialResolution["origin"] = {};
+
+  for (const field of ["daytonaApiKey", "openaiApiKey"] as const) {
+    for (const [source, values] of order) {
+      const value = clean(values?.[field]);
+      if (value) {
+        credentials[field] = value;
+        origin[field] = source;
+        break;
+      }
+    }
+  }
+
+  const missing = (["daytonaApiKey", "openaiApiKey"] as const).filter(
+    (field) => !credentials[field],
+  );
+
+  return { credentials, origin, missing };
+}

--- a/apps/web/app/_lib/credentials.ts
+++ b/apps/web/app/_lib/credentials.ts
@@ -1,0 +1,160 @@
+import "server-only";
+
+import { getWorkOS } from "@workos-inc/authkit-nextjs";
+
+import type { ResolvedCredentials } from "./credentials-resolver";
+
+/**
+ * Per-user secret storage backed by WorkOS Vault.
+ *
+ * Each user's Daytona and OpenAI keys are stored as individual encrypted Vault
+ * objects, namespaced by the WorkOS user id. The encryption key context is
+ * scoped to the user so objects are cryptographically isolated per user.
+ *
+ * Plaintext values never reach the browser: callers either pass them straight
+ * to the SDK on the server, or request a masked status for display.
+ */
+
+export type CredentialKind = "daytona" | "openai";
+
+export type CredentialStatus = {
+  /** Whether a value is stored for this credential. */
+  set: boolean;
+  /** Masked hint (last 4 chars) for display, when set. */
+  hint?: string;
+  /** ISO timestamp the value was last updated, when available. */
+  updatedAt?: string;
+};
+
+export type UserCredentialStatus = Record<CredentialKind, CredentialStatus>;
+
+const FIELD_BY_KIND: Record<CredentialKind, keyof ResolvedCredentials> = {
+  daytona: "daytonaApiKey",
+  openai: "openaiApiKey",
+};
+
+function vaultName(userId: string, kind: CredentialKind): string {
+  return `getdesign.user.${userId}.${kind}-api-key`;
+}
+
+function maskHint(value: string): string {
+  const tail = value.slice(-4);
+  return tail.length > 0 ? `••••${tail}` : "••••";
+}
+
+/**
+ * Distinguish "object does not exist" from real failures. WorkOS surfaces a
+ * 404 for unknown Vault objects; we treat that as "not set" and re-throw the
+ * rest so genuine misconfiguration is visible.
+ */
+function isNotFound(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const status = (error as { status?: number; statusCode?: number }).status ??
+    (error as { statusCode?: number }).statusCode;
+  if (status === 404) return true;
+  const code = (error as { code?: string }).code;
+  if (code === "entity_not_found" || code === "object_not_found") return true;
+  const message = (error as { message?: string }).message ?? "";
+  return /not\s*found/i.test(message);
+}
+
+type VaultObjectLike = {
+  id: string;
+  value: string;
+  metadata?: { versionId?: string; updatedAt?: string };
+};
+
+async function readVaultObject(
+  userId: string,
+  kind: CredentialKind,
+): Promise<VaultObjectLike | null> {
+  const workos = getWorkOS();
+  try {
+    const object = (await workos.vault.readObjectByName(
+      vaultName(userId, kind),
+    )) as unknown as VaultObjectLike;
+    return object;
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+}
+
+/** Store (create or update) a single credential for a user. */
+export async function saveUserCredential(
+  userId: string,
+  kind: CredentialKind,
+  value: string,
+): Promise<void> {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Refusing to store an empty credential.");
+  }
+
+  const workos = getWorkOS();
+  const existing = await readVaultObject(userId, kind);
+
+  if (existing) {
+    await workos.vault.updateObject({
+      id: existing.id,
+      value: trimmed,
+      versionCheck: existing.metadata?.versionId,
+    });
+    return;
+  }
+
+  await workos.vault.createObject({
+    name: vaultName(userId, kind),
+    value: trimmed,
+    context: { userId },
+  });
+}
+
+/** Remove a stored credential for a user. No-op if it was never set. */
+export async function clearUserCredential(
+  userId: string,
+  kind: CredentialKind,
+): Promise<void> {
+  const existing = await readVaultObject(userId, kind);
+  if (!existing) return;
+  const workos = getWorkOS();
+  await workos.vault.deleteObject({ id: existing.id });
+}
+
+/** Read all of a user's stored credentials as plaintext (server-side only). */
+export async function getUserCredentials(
+  userId: string,
+): Promise<ResolvedCredentials> {
+  const [daytona, openai] = await Promise.all([
+    readVaultObject(userId, "daytona"),
+    readVaultObject(userId, "openai"),
+  ]);
+
+  const credentials: ResolvedCredentials = {};
+  if (daytona?.value) credentials.daytonaApiKey = daytona.value;
+  if (openai?.value) credentials.openaiApiKey = openai.value;
+  return credentials;
+}
+
+/** Masked, display-safe status of a user's stored credentials. */
+export async function getUserCredentialStatus(
+  userId: string,
+): Promise<UserCredentialStatus> {
+  const [daytona, openai] = await Promise.all([
+    readVaultObject(userId, "daytona"),
+    readVaultObject(userId, "openai"),
+  ]);
+
+  const toStatus = (object: VaultObjectLike | null): CredentialStatus =>
+    object?.value
+      ? {
+          set: true,
+          hint: maskHint(object.value),
+          updatedAt: object.metadata?.updatedAt,
+        }
+      : { set: false };
+
+  return { daytona: toStatus(daytona), openai: toStatus(openai) };
+}
+
+export { FIELD_BY_KIND };

--- a/apps/web/app/_lib/workos.ts
+++ b/apps/web/app/_lib/workos.ts
@@ -1,0 +1,18 @@
+/**
+ * WorkOS configuration detection.
+ *
+ * Kept dependency-free (no SDK import, no `server-only`) so it can run in the
+ * Next.js proxy/edge runtime and be imported anywhere. The actual WorkOS client
+ * and Vault access live in `credentials.ts`, which is server-only.
+ *
+ * When WorkOS is not configured the app degrades gracefully to "local mode":
+ * authentication is skipped and the dashboard relies on request-scoped BYOK
+ * keys or `DAYTONA_API_KEY` / `OPENAI_API_KEY` environment variables.
+ */
+export function isWorkOSConfigured(): boolean {
+  return Boolean(
+    process.env.WORKOS_API_KEY &&
+      process.env.WORKOS_CLIENT_ID &&
+      process.env.WORKOS_COOKIE_PASSWORD,
+  );
+}

--- a/apps/web/app/api/design/route.ts
+++ b/apps/web/app/api/design/route.ts
@@ -1,5 +1,13 @@
 import { streamDesign, type DesignStreamEvent } from "@getdesign/sdk";
 
+import { getCurrentUser } from "../../_lib/auth";
+import { getUserCredentials } from "../../_lib/credentials";
+import {
+  resolveCredentials,
+  type ResolvedCredentials,
+} from "../../_lib/credentials-resolver";
+import { isWorkOSConfigured } from "../../_lib/workos";
+
 export const runtime = "nodejs";
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -38,6 +46,39 @@ function encodeLine(event: DesignStreamEvent, encoder: TextEncoder): Uint8Array 
   return encoder.encode(`${JSON.stringify(event)}\n`);
 }
 
+function envCredentials(): ResolvedCredentials {
+  return {
+    daytonaApiKey: process.env.DAYTONA_API_KEY,
+    openaiApiKey: process.env.OPENAI_API_KEY,
+  };
+}
+
+/**
+ * Resolve the keys for a run by priority: request body (BYOK) > the signed-in
+ * user's WorkOS Vault secrets > local environment variables.
+ */
+async function resolveRunCredentials(request: ResolvedCredentials) {
+  let vault: ResolvedCredentials | undefined;
+
+  if (isWorkOSConfigured()) {
+    try {
+      const user = await getCurrentUser();
+      if (user) {
+        vault = await getUserCredentials(user.id);
+      }
+    } catch {
+      // Treat Vault/auth failures as "no stored credentials" and fall through
+      // to env-var resolution; the run still fails cleanly if nothing resolves.
+    }
+  }
+
+  return resolveCredentials({
+    request,
+    vault,
+    env: envCredentials(),
+  });
+}
+
 export async function POST(request: Request) {
   let body: DesignRequestBody;
   try {
@@ -55,15 +96,20 @@ export async function POST(request: Request) {
     );
   }
 
-  const daytonaApiKey = stringField(body.daytonaApiKey);
-  const openaiApiKey = stringField(body.openaiApiKey);
-  if (!daytonaApiKey || !openaiApiKey) {
+  const credentials = await resolveRunCredentials({
+    daytonaApiKey: stringField(body.daytonaApiKey),
+    openaiApiKey: stringField(body.openaiApiKey),
+  });
+
+  if (credentials.missing.length > 0) {
     return jsonError(
       400,
       "missing_credentials",
-      "Provide your own Daytona and OpenAI API keys to run a design.",
+      "No Daytona and OpenAI keys found. Enter them below, save them in Settings, or set DAYTONA_API_KEY / OPENAI_API_KEY locally.",
     );
   }
+
+  const { daytonaApiKey, openaiApiKey } = credentials.credentials;
 
   const siteName = stringField(body.siteName);
   const visualRequirement =

--- a/apps/web/app/callback/route.ts
+++ b/apps/web/app/callback/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server";
+
+import { isWorkOSConfigured } from "../_lib/workos";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * AuthKit redirect callback. Exchanges the authorization code for a session and
+ * returns the user to the dashboard. Disabled in local mode (no WorkOS config).
+ */
+export async function GET(request: NextRequest): Promise<Response> {
+  if (!isWorkOSConfigured()) {
+    return new Response("WorkOS authentication is not configured.", {
+      status: 404,
+    });
+  }
+
+  const { handleAuth } = await import("@workos-inc/authkit-nextjs");
+  return handleAuth({ returnPathname: "/dashboard" })(request);
+}

--- a/apps/web/app/dashboard/_components/dashboard-runner.tsx
+++ b/apps/web/app/dashboard/_components/dashboard-runner.tsx
@@ -7,6 +7,7 @@ import type { DesignStreamEvent } from "@getdesign/sdk";
 import { PhaseList } from "./phase-list";
 import { ResultViewer } from "./result-viewer";
 import type {
+  DashboardAccess,
   DashboardResult,
   DashboardStatus,
   PhaseId,
@@ -44,7 +45,10 @@ const INITIAL_FORM: FormState = {
   rememberKeys: false,
 };
 
-export function DashboardRunner() {
+export function DashboardRunner({ access }: { access: DashboardAccess }) {
+  const daytonaFromServer = access.stored.daytona || access.env.daytona;
+  const openaiFromServer = access.stored.openai || access.env.openai;
+
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
   const [status, setStatus] = useState<DashboardStatus>("idle");
   const [phases, setPhases] = useState<Record<PhaseId, PhaseState>>(
@@ -198,9 +202,20 @@ export function DashboardRunner() {
         setErrorMessage("Enter a URL to design.");
         return;
       }
-      if (!daytona || !openai) {
+
+      const daytonaReady = Boolean(daytona) || daytonaFromServer;
+      const openaiReady = Boolean(openai) || openaiFromServer;
+      if (!daytonaReady || !openaiReady) {
+        const missing = [
+          !daytonaReady ? "Daytona" : null,
+          !openaiReady ? "OpenAI" : null,
+        ]
+          .filter(Boolean)
+          .join(" and ");
         setStatus("error");
-        setErrorMessage("Provide both Daytona and OpenAI API keys.");
+        setErrorMessage(
+          `Provide your ${missing} key${missing.includes("and") ? "s" : ""}, or save ${missing.includes("and") ? "them" : "it"} in Settings.`,
+        );
         return;
       }
 
@@ -224,8 +239,8 @@ export function DashboardRunner() {
           body: JSON.stringify({
             url,
             siteName: form.siteName.trim() || undefined,
-            daytonaApiKey: daytona,
-            openaiApiKey: openai,
+            daytonaApiKey: daytona || undefined,
+            openaiApiKey: openai || undefined,
           }),
         });
 
@@ -291,7 +306,7 @@ export function DashboardRunner() {
         abortRef.current = null;
       }
     },
-    [applyEvent, form, persistKeys, status],
+    [applyEvent, daytonaFromServer, form, openaiFromServer, persistKeys, status],
   );
 
   const cancel = useCallback(() => {
@@ -371,10 +386,14 @@ export function DashboardRunner() {
 
           <div className="my-5 dashed-top h-px" />
 
+          <CredentialBanner access={access} />
+
           <div className="mb-3 flex items-center justify-between text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
             <span>BYOK credentials</span>
             <span className="font-mono normal-case tracking-normal text-[var(--subtle)]">
-              never persisted server-side
+              {daytonaFromServer && openaiFromServer
+                ? "optional override"
+                : "never persisted server-side"}
             </span>
           </div>
 
@@ -401,11 +420,10 @@ export function DashboardRunner() {
               type="password"
               autoComplete="off"
               spellCheck={false}
-              placeholder="dt_live_..."
+              placeholder={daytonaFromServer ? "Using saved key — override here" : "dt_live_..."}
               value={form.daytonaApiKey}
               onChange={(e) => handleField("daytonaApiKey", e.target.value)}
               disabled={isRunning}
-              required
               className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)] disabled:opacity-60"
             />
           </Field>
@@ -433,11 +451,10 @@ export function DashboardRunner() {
               type="password"
               autoComplete="off"
               spellCheck={false}
-              placeholder="sk-..."
+              placeholder={openaiFromServer ? "Using saved key — override here" : "sk-..."}
               value={form.openaiApiKey}
               onChange={(e) => handleField("openaiApiKey", e.target.value)}
               disabled={isRunning}
-              required
               className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)] disabled:opacity-60"
             />
           </Field>
@@ -531,6 +548,64 @@ function formatElapsed(ms: number): string {
   const m = Math.floor(seconds / 60);
   const s = Math.round(seconds - m * 60);
   return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
+function CredentialBanner({ access }: { access: DashboardAccess }) {
+  const bothStored = access.stored.daytona && access.stored.openai;
+  const bothEnv = access.env.daytona && access.env.openai;
+
+  let message: React.ReactNode;
+  let action: React.ReactNode = null;
+
+  if (access.workosConfigured && access.userEmail) {
+    message = bothStored ? (
+      <>
+        Using your saved keys for{" "}
+        <span className="text-foreground">{access.userEmail}</span>. Leave the
+        fields blank, or override below.
+      </>
+    ) : (
+      <>
+        Signed in as{" "}
+        <span className="text-foreground">{access.userEmail}</span>. Save your
+        keys once so you don&apos;t paste them every run.
+      </>
+    );
+    action = (
+      <a
+        href="/dashboard/settings"
+        className="btn-ghost shrink-0 rounded-md px-3 py-1.5 text-[11.5px]"
+      >
+        Settings
+      </a>
+    );
+  } else if (access.workosConfigured) {
+    message = <>Sign in to securely store your keys in WorkOS Vault and reuse them.</>;
+    action = (
+      <a
+        href="/login"
+        className="btn-ghost shrink-0 rounded-md px-3 py-1.5 text-[11.5px]"
+      >
+        Sign in
+      </a>
+    );
+  } else if (bothEnv) {
+    message = (
+      <>
+        Local keys detected from environment variables. Run without entering
+        anything, or override below.
+      </>
+    );
+  } else {
+    return null;
+  }
+
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 py-2.5 text-[11.5px] text-muted">
+      <span>{message}</span>
+      {action}
+    </div>
+  );
 }
 
 type FieldProps = {

--- a/apps/web/app/dashboard/_components/types.ts
+++ b/apps/web/app/dashboard/_components/types.ts
@@ -17,3 +17,15 @@ export type DashboardResult = Extract<
   DesignStreamEvent,
   { type: "result" }
 >["result"];
+
+/** Server-evaluated credential availability passed to the runner. */
+export type DashboardAccess = {
+  /** Whether WorkOS auth + Vault are configured for this deployment. */
+  workosConfigured: boolean;
+  /** Email of the signed-in user, or `null` when signed out / local mode. */
+  userEmail: string | null;
+  /** Whether the signed-in user has each key stored in WorkOS Vault. */
+  stored: { daytona: boolean; openai: boolean };
+  /** Whether each key is available via environment variables (local dev). */
+  env: { daytona: boolean; openai: boolean };
+};

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,8 +2,12 @@ import type { Metadata } from "next";
 
 import { MarketingShell } from "../_components/marketing-shell";
 import { SiteFooter } from "../_components/site-footer";
+import { getCurrentUser } from "../_lib/auth";
+import { getUserCredentialStatus } from "../_lib/credentials";
+import { isWorkOSConfigured } from "../_lib/workos";
 import { DashboardHeader } from "./_components/dashboard-header";
 import { DashboardRunner } from "./_components/dashboard-runner";
+import type { DashboardAccess } from "./_components/types";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -26,11 +30,48 @@ export const metadata: Metadata = {
   },
 };
 
-export default function DashboardPage() {
+export const dynamic = "force-dynamic";
+
+async function resolveAccess(): Promise<DashboardAccess> {
+  const env = {
+    daytona: Boolean(process.env.DAYTONA_API_KEY),
+    openai: Boolean(process.env.OPENAI_API_KEY),
+  };
+
+  if (!isWorkOSConfigured()) {
+    return {
+      workosConfigured: false,
+      userEmail: null,
+      stored: { daytona: false, openai: false },
+      env,
+    };
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return {
+      workosConfigured: true,
+      userEmail: null,
+      stored: { daytona: false, openai: false },
+      env,
+    };
+  }
+
+  const status = await getUserCredentialStatus(user.id);
+  return {
+    workosConfigured: true,
+    userEmail: user.email,
+    stored: { daytona: status.daytona.set, openai: status.openai.set },
+    env,
+  };
+}
+
+export default async function DashboardPage() {
+  const access = await resolveAccess();
   return (
     <MarketingShell footer={<SiteFooter />}>
       <DashboardHeader />
-      <DashboardRunner />
+      <DashboardRunner access={access} />
     </MarketingShell>
   );
 }

--- a/apps/web/app/dashboard/settings/_components/settings-form.tsx
+++ b/apps/web/app/dashboard/settings/_components/settings-form.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { updateCredentialsAction } from "../actions";
+import { INITIAL_SETTINGS_STATE } from "../actions-state";
+
+type FieldStatus = { set: boolean; hint?: string };
+
+type SettingsFormProps = {
+  daytona: FieldStatus;
+  openai: FieldStatus;
+};
+
+export function SettingsForm({ daytona, openai }: SettingsFormProps) {
+  const [state, formAction] = useActionState(
+    updateCredentialsAction,
+    INITIAL_SETTINGS_STATE,
+  );
+
+  return (
+    <form
+      action={formAction}
+      className="rounded-xl border border-[var(--border)] bg-[var(--surface-100)] p-5"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <div className="text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
+          BYOK credentials
+        </div>
+        <div className="font-mono text-[10.5px] text-[var(--subtle)]">
+          encrypted · WorkOS Vault
+        </div>
+      </div>
+
+      <CredentialField
+        id="daytonaApiKey"
+        label="Daytona API key"
+        placeholder="dt_live_..."
+        status={daytona}
+        clearIntent="clear-daytona"
+        helper={
+          <>
+            Launches the capture sandbox. Get one at{" "}
+            <a
+              href="https://app.daytona.io/dashboard/keys"
+              target="_blank"
+              rel="noreferrer"
+              className="text-foreground underline-offset-4 hover:underline"
+            >
+              app.daytona.io
+            </a>
+            .
+          </>
+        }
+      />
+
+      <CredentialField
+        id="openaiApiKey"
+        label="OpenAI API key"
+        placeholder="sk-..."
+        status={openai}
+        clearIntent="clear-openai"
+        helper={
+          <>
+            Used for visual description and synthesis. Get one at{" "}
+            <a
+              href="https://platform.openai.com/api-keys"
+              target="_blank"
+              rel="noreferrer"
+              className="text-foreground underline-offset-4 hover:underline"
+            >
+              platform.openai.com
+            </a>
+            .
+          </>
+        }
+      />
+
+      {state.status !== "idle" && state.message ? (
+        <div
+          role="status"
+          className={`mt-1 rounded-md border px-3 py-2 text-[12px] ${
+            state.status === "ok"
+              ? "border-[var(--border-strong)] text-foreground"
+              : "border-red-500/40 text-red-400"
+          }`}
+        >
+          {state.message}
+        </div>
+      ) : null}
+
+      <div className="mt-6 flex items-center gap-2">
+        <SaveButton />
+      </div>
+
+      <p className="mt-4 text-[11.5px] leading-relaxed text-[var(--subtle)]">
+        Keys are encrypted at rest in WorkOS Vault, scoped to your account, and
+        only ever decrypted server-side to run your designs. They are never sent
+        back to the browser.
+      </p>
+    </form>
+  );
+}
+
+type CredentialFieldProps = {
+  id: string;
+  label: string;
+  placeholder: string;
+  status: FieldStatus;
+  clearIntent: string;
+  helper: React.ReactNode;
+};
+
+function CredentialField({
+  id,
+  label,
+  placeholder,
+  status,
+  clearIntent,
+  helper,
+}: CredentialFieldProps) {
+  return (
+    <div className="mb-4">
+      <div className="mb-1.5 flex items-center justify-between">
+        <label
+          htmlFor={id}
+          className="block text-[11px] uppercase tracking-[0.16em] text-[var(--subtle)]"
+        >
+          {label}
+        </label>
+        {status.set ? (
+          <span className="font-mono text-[10.5px] text-[var(--accent)]">
+            saved · {status.hint}
+          </span>
+        ) : (
+          <span className="font-mono text-[10.5px] text-[var(--subtle)]">
+            not set
+          </span>
+        )}
+      </div>
+      <input
+        id={id}
+        name={id}
+        type="password"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={status.set ? "•••••••• (leave blank to keep)" : placeholder}
+        className="h-10 w-full rounded-md border border-[var(--border-strong)] bg-[var(--background)] px-3 font-mono text-[13px] text-foreground placeholder:text-[var(--subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--border-strong)]"
+      />
+      <div className="mt-1.5 flex items-center justify-between gap-3">
+        <div className="text-[11.5px] text-[var(--subtle)]">{helper}</div>
+        {status.set ? (
+          <button
+            type="submit"
+            name="intent"
+            value={clearIntent}
+            className="btn-ghost shrink-0 rounded-md px-2 py-1 text-[11px] text-[var(--subtle)] hover:text-foreground"
+          >
+            Remove
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SaveButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      name="intent"
+      value="save"
+      disabled={pending}
+      className="btn-accent inline-flex h-9 items-center rounded-md px-4 text-[12.5px] font-medium disabled:opacity-60"
+    >
+      {pending ? "Saving…" : "Save keys"}
+    </button>
+  );
+}

--- a/apps/web/app/dashboard/settings/actions-state.ts
+++ b/apps/web/app/dashboard/settings/actions-state.ts
@@ -1,0 +1,6 @@
+export type SettingsActionState = {
+  status: "idle" | "ok" | "error";
+  message?: string;
+};
+
+export const INITIAL_SETTINGS_STATE: SettingsActionState = { status: "idle" };

--- a/apps/web/app/dashboard/settings/actions.ts
+++ b/apps/web/app/dashboard/settings/actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getCurrentUser } from "../../_lib/auth";
+import {
+  clearUserCredential,
+  saveUserCredential,
+  type CredentialKind,
+} from "../../_lib/credentials";
+import type { SettingsActionState } from "./actions-state";
+
+function field(formData: FormData, name: string): string {
+  const value = formData.get(name);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Persist or clear a user's BYOK credentials in WorkOS Vault.
+ *
+ * The form posts an `intent`:
+ *  - `save`         — store any non-empty Daytona / OpenAI keys provided.
+ *  - `clear-daytona`/`clear-openai` — remove that stored key.
+ */
+export async function updateCredentialsAction(
+  _prevState: SettingsActionState,
+  formData: FormData,
+): Promise<SettingsActionState> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { status: "error", message: "You must be signed in to save keys." };
+  }
+
+  const intent = field(formData, "intent") || "save";
+
+  try {
+    if (intent === "clear-daytona" || intent === "clear-openai") {
+      const kind: CredentialKind =
+        intent === "clear-daytona" ? "daytona" : "openai";
+      await clearUserCredential(user.id, kind);
+      revalidatePath("/dashboard/settings");
+      return {
+        status: "ok",
+        message: `Removed your ${kind === "daytona" ? "Daytona" : "OpenAI"} key.`,
+      };
+    }
+
+    const daytona = field(formData, "daytonaApiKey");
+    const openai = field(formData, "openaiApiKey");
+
+    if (!daytona && !openai) {
+      return {
+        status: "error",
+        message: "Enter a Daytona or OpenAI key to save.",
+      };
+    }
+
+    const saved: string[] = [];
+    if (daytona) {
+      await saveUserCredential(user.id, "daytona", daytona);
+      saved.push("Daytona");
+    }
+    if (openai) {
+      await saveUserCredential(user.id, "openai", openai);
+      saved.push("OpenAI");
+    }
+
+    revalidatePath("/dashboard/settings");
+    return { status: "ok", message: `Saved your ${saved.join(" and ")} key${saved.length > 1 ? "s" : ""}.` };
+  } catch (error) {
+    return {
+      status: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Could not update your credentials.",
+    };
+  }
+}
+
+/** End the current AuthKit session. */
+export async function signOutAction(): Promise<void> {
+  const { signOut } = await import("@workos-inc/authkit-nextjs");
+  await signOut();
+}

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { MarketingShell } from "../../_components/marketing-shell";
+import { SiteFooter } from "../../_components/site-footer";
+import { getCurrentUser } from "../../_lib/auth";
+import { getUserCredentialStatus } from "../../_lib/credentials";
+import { isWorkOSConfigured } from "../../_lib/workos";
+import { signOutAction } from "./actions";
+import { SettingsForm } from "./_components/settings-form";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Manage the API keys getdesign uses to run your designs.",
+  alternates: { canonical: "/dashboard/settings" },
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  return (
+    <MarketingShell footer={<SiteFooter />}>
+      <Header />
+      <section className="px-6 pb-24 pt-10">
+        <div className="mx-auto max-w-xl">
+          <SettingsBody />
+        </div>
+      </section>
+    </MarketingShell>
+  );
+}
+
+function Header() {
+  return (
+    <section className="dashed-bottom px-6 py-16 sm:py-20">
+      <div className="flex items-center gap-2 text-[12px] text-muted">
+        <span className="text-[var(--accent)]">✦</span>
+        Settings
+      </div>
+      <h1 className="display-hero mt-6 max-w-[820px]">
+        Your <span className="text-foreground">keys</span>
+        <span className="text-[var(--accent)]">.</span>
+      </h1>
+      <p className="mt-6 max-w-[560px] text-[14.5px] leading-relaxed text-muted">
+        Save your Daytona and OpenAI keys once. The dashboard reuses them for
+        every run so you don&apos;t have to paste them each time.
+      </p>
+    </section>
+  );
+}
+
+async function SettingsBody() {
+  if (!isWorkOSConfigured()) {
+    return <LocalModeNotice />;
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return <SignInPrompt />;
+  }
+
+  const status = await getUserCredentialStatus(user.id);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-100)] px-4 py-3">
+        <div className="text-[12.5px] text-muted">
+          Signed in as{" "}
+          <span className="text-foreground">{user.email}</span>
+        </div>
+        <form action={signOutAction}>
+          <button
+            type="submit"
+            className="btn-ghost rounded-md px-3 py-1.5 text-[12px]"
+          >
+            Sign out
+          </button>
+        </form>
+      </div>
+
+      <SettingsForm
+        daytona={{ set: status.daytona.set, hint: status.daytona.hint }}
+        openai={{ set: status.openai.set, hint: status.openai.hint }}
+      />
+
+      <div className="text-center">
+        <Link
+          href="/dashboard"
+          className="text-[12.5px] text-[var(--subtle)] underline-offset-4 hover:text-foreground hover:underline"
+        >
+          ← Back to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function SignInPrompt() {
+  return (
+    <div className="dashed-frame rounded-xl bg-[var(--surface-100)] px-6 py-14 text-center">
+      <div className="mx-auto max-w-sm space-y-5">
+        <p className="text-[13.5px] text-muted">
+          Sign in to securely store your Daytona and OpenAI keys in WorkOS Vault
+          and reuse them across runs.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <a
+            href="/login"
+            className="btn-accent inline-flex h-9 items-center rounded-md px-4 text-[12.5px] font-medium"
+          >
+            Sign in
+          </a>
+          <a
+            href="/login?screen=sign-up"
+            className="btn-ghost inline-flex h-9 items-center rounded-md px-4 text-[12.5px]"
+          >
+            Create account
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LocalModeNotice() {
+  return (
+    <div className="dashed-frame rounded-xl bg-[var(--surface-100)] px-6 py-14 text-center">
+      <div className="mx-auto max-w-md space-y-4">
+        <div className="font-mono text-[10.5px] uppercase tracking-[0.2em] text-[var(--subtle)]">
+          local mode
+        </div>
+        <p className="text-[13.5px] text-muted">
+          Account-based key storage requires WorkOS to be configured. Set{" "}
+          <code className="font-mono text-foreground">WORKOS_API_KEY</code>,{" "}
+          <code className="font-mono text-foreground">WORKOS_CLIENT_ID</code>,
+          and{" "}
+          <code className="font-mono text-foreground">
+            WORKOS_COOKIE_PASSWORD
+          </code>{" "}
+          to enable sign-in and WorkOS Vault.
+        </p>
+        <p className="text-[12.5px] text-[var(--subtle)]">
+          Without WorkOS, the dashboard still runs using keys entered in the form
+          or the{" "}
+          <code className="font-mono text-foreground">DAYTONA_API_KEY</code> /{" "}
+          <code className="font-mono text-foreground">OPENAI_API_KEY</code>{" "}
+          environment variables.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-block text-[12.5px] text-[var(--subtle)] underline-offset-4 hover:text-foreground hover:underline"
+        >
+          ← Back to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, JetBrains_Mono } from "next/font/google";
+import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 
 import { JsonLd } from "./_components/json-ld";
 import { SITE_DOMAIN, SITE_GITHUB_URL, SITE_NAME } from "./_lib/site";
+import { isWorkOSConfigured } from "./_lib/workos";
 
 import "./globals.css";
 
@@ -146,11 +148,21 @@ export default function RootLayout({
     ],
   };
 
+  const content = (
+    <>
+      {children}
+      <JsonLd data={jsonLd} />
+    </>
+  );
+
   return (
     <html lang="en" className={`${geist.variable} ${jetbrains.variable}`}>
       <body>
-        {children}
-        <JsonLd data={jsonLd} />
+        {isWorkOSConfigured() ? (
+          <AuthKitProvider>{content}</AuthKitProvider>
+        ) : (
+          content
+        )}
       </body>
     </html>
   );

--- a/apps/web/app/login/route.ts
+++ b/apps/web/app/login/route.ts
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+
+import { isWorkOSConfigured } from "../_lib/workos";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Kicks off the AuthKit hosted sign-in flow. `screenHint=sign-up` opens the
+ * sign-up screen instead. Falls back to the dashboard in local mode.
+ */
+export async function GET(request: Request): Promise<Response> {
+  if (!isWorkOSConfigured()) {
+    redirect("/dashboard");
+  }
+
+  const wantsSignUp = new URL(request.url).searchParams.get("screen") === "sign-up";
+  const { getSignInUrl, getSignUpUrl } = await import(
+    "@workos-inc/authkit-nextjs"
+  );
+  const url = wantsSignUp ? await getSignUpUrl() : await getSignInUrl();
+  redirect(url);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@getdesign/sdk": "workspace:*",
     "@icons-pack/react-simple-icons": "^13.13.0",
+    "@workos-inc/authkit-nextjs": "^4.1.1",
+    "@workos-inc/node": "^10.0.0",
     "convex": "^1.35.1",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,24 @@
+import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+
+import { isWorkOSConfigured } from "./app/_lib/workos";
+
+/**
+ * AuthKit session management runs on every matched route, but authentication is
+ * enforced per-page via `withAuth({ ensureSignedIn })` rather than globally —
+ * the marketing site and the BYOK dashboard stay public.
+ *
+ * When WorkOS is not configured (local development without credentials), the
+ * proxy is a pass-through so the app keeps working with env-var keys.
+ */
+const proxy = isWorkOSConfigured()
+  ? authkitMiddleware()
+  : () => NextResponse.next();
+
+export default proxy;
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|txt)$).*)",
+  ],
+};

--- a/bun.lock
+++ b/bun.lock
@@ -166,6 +166,8 @@
       "dependencies": {
         "@getdesign/sdk": "workspace:*",
         "@icons-pack/react-simple-icons": "^13.13.0",
+        "@workos-inc/authkit-nextjs": "^4.1.1",
+        "@workos-inc/node": "^10.0.0",
         "convex": "^1.35.1",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -1268,6 +1270,8 @@
 
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
 
+    "@sindresorhus/fnv1a": ["@sindresorhus/fnv1a@3.1.0", "", {}, "sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
@@ -1649,6 +1653,10 @@
     "@webassemblyjs/wasm-parser": ["@webassemblyjs/wasm-parser@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@webassemblyjs/helper-api-error": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2", "@webassemblyjs/ieee754": "1.13.2", "@webassemblyjs/leb128": "1.13.2", "@webassemblyjs/utf8": "1.13.2" } }, "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ=="],
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
+
+    "@workos-inc/authkit-nextjs": ["@workos-inc/authkit-nextjs@4.1.1", "", { "dependencies": { "@sindresorhus/fnv1a": "^3.1.0", "@workos-inc/node": "^9.0.0", "iron-session": "^8.0.4", "jose": "^5.10.0", "path-to-regexp": "^6.3.0", "valibot": "^1.2.0" }, "peerDependencies": { "next": "^13.5.9 || ^14.2.26 || ^15.2.3 || ^16", "react": "^18.0 || ^19.0.0", "react-dom": "^18.0 || ^19.0.0" } }, "sha512-j7kf3xw2inF8UdhrOOQMoIkCPJaf7CppmJtagDqpeLO9uLoVpnickJCOkrCpY16hIWcJPGdmXTOeaEPIYtu5XQ=="],
+
+    "@workos-inc/node": ["@workos-inc/node@10.0.0", "", { "dependencies": { "eventemitter3": "^5.0.4" } }, "sha512-Vnqd/TAoNZSYTW7FSxR/f+BnWMyffK0ueX+KNBnoahMHOcLCMiF3Y5Rkt4VIdRdvvhQ+pR2JgcwCHIEcE1OXWw=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
@@ -2526,6 +2534,8 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "iron-session": ["iron-session@8.0.4", "", { "dependencies": { "cookie": "^0.7.2", "iron-webcrypto": "^1.2.1", "uncrypto": "^0.1.3" } }, "sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA=="],
+
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
@@ -2586,7 +2596,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3606,6 +3616,8 @@
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
+    "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
+
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -3996,6 +4008,8 @@
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@modelcontextprotocol/sdk/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
@@ -4186,6 +4200,8 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
+    "@workos-inc/authkit-nextjs/@workos-inc/node": ["@workos-inc/node@9.3.1", "", { "dependencies": { "eventemitter3": "^5.0.4" } }, "sha512-z6+V5lPAdEtJ2IklAsOUJWv5guihkMbtC8WHmLCKOJYLa/H0j9bRj/OmxTs7T+bzL2dhItxPRarhxlAAq/0jgQ=="],
+
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -4319,6 +4335,8 @@
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
+
+    "iron-session/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on the live `/dashboard` (PR #16). The dashboard previously required users to paste their Daytona + OpenAI keys (or remember them in `localStorage`) on every run. This adds per-user, server-side key storage backed by **WorkOS AuthKit + Vault**, while keeping env vars working for local development.

- The design API now resolves credentials per run in priority order: **request body (BYOK) → signed-in user's WorkOS Vault secrets → `DAYTONA_API_KEY` / `OPENAI_API_KEY` env vars (local dev)**.
- Adds WorkOS AuthKit sign-in (`proxy.ts`, `/login`, `/callback`, `AuthKitProvider`) and a `/dashboard/settings` page where each user stores their keys, encrypted in WorkOS Vault and scoped to their user id.
- Degrades gracefully to **local mode** (no auth, env/BYOK only) when WorkOS is not configured, so local development is unchanged.

Base: this PR is stacked on `cursor/dashboard-ui-ba70`.

## Surface(s) affected

- [x] Web (`apps/web`)

## Breaking changes?

- [x] No

## How credentials resolve

Each key resolves independently (a user can keep one in Vault and override the other for a single run):

| Priority | Source | Notes |
| --- | --- | --- |
| 1 | Request body | BYOK keys typed into the dashboard form; never persisted server-side |
| 2 | WorkOS Vault | Per-user keys saved at `/dashboard/settings`, decrypted only server-side |
| 3 | Env vars | `DAYTONA_API_KEY` / `OPENAI_API_KEY` — local-dev fallback |

When `WORKOS_API_KEY` / `WORKOS_CLIENT_ID` / `WORKOS_COOKIE_PASSWORD` are unset, the app stays in local mode: the proxy is a pass-through, sign-in/settings show a "local mode" notice, and the BYOK form + env vars still work.

## Screenshots / output samples

Dashboard in local mode — keys detected from environment variables, fields become optional overrides:

[Dashboard local keys banner](https://cursor.com/agents/bc-36a82132-0988-4d0f-b09e-e0ae3e7f13bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_local_keys_banner.webp)

Settings page in local mode — explains the WorkOS config needed to enable account-based Vault storage:

[Settings local mode notice](https://cursor.com/agents/bc-36a82132-0988-4d0f-b09e-e0ae3e7f13bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_local_mode_notice.webp)

Walkthrough:

[dashboard_localmode_and_settings_walkthrough.mp4](https://cursor.com/agents/bc-36a82132-0988-4d0f-b09e-e0ae3e7f13bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_localmode_and_settings_walkthrough.mp4)

## Files

- `app/_lib/workos.ts` — WorkOS config detection (`isWorkOSConfigured`).
- `app/_lib/auth.ts` — `getCurrentUser()` (guarded `withAuth`).
- `app/_lib/credentials.ts` — WorkOS Vault per-user secret read/save/clear + masked status.
- `app/_lib/credentials-resolver.ts` (+ `.test.ts`) — pure body→vault→env priority resolver, unit tested.
- `app/api/design/route.ts` — resolves run credentials via the chain; keys now optional.
- `app/dashboard/settings/*` — settings page, server actions, client form.
- `proxy.ts`, `app/callback/route.ts`, `app/login/route.ts`, `app/layout.tsx` — AuthKit wiring (all gated on config).
- `app/dashboard/page.tsx`, `_components/dashboard-runner.tsx`, `_components/types.ts` — auth/credentials banner + optional form keys.
- `apps/web/README.md` — documents the env vars and credential model.

## Verification

- `bun run typecheck` (apps/web) — passes
- `bun run build` (apps/web) — passes; `/callback`, `/login`, `/dashboard/settings` and Proxy show in the route table
- `bun test app/_lib/credentials-resolver.test.ts` — 6/6 pass
- Runtime: `POST /api/design` returns `400 missing_credentials` with no keys/env; resolves and runs the SDK when keys come from the body or from env vars
- Manual: dashboard local-keys banner and settings local-mode notice verified in the browser (see walkthrough)

## Checklist

- [x] Conventional-commit title
- [ ] `bun run lint` passes
- [x] `bun run typecheck` passes
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`

Note: the WorkOS Vault path itself (signed-in storage) could not be exercised end-to-end here because no WorkOS account/credentials are available in this environment; the resolver, env-var fallback, and local-mode UI are tested above.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36a82132-0988-4d0f-b09e-e0ae3e7f13bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36a82132-0988-4d0f-b09e-e0ae3e7f13bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

