### PR TITLE
Fix dashboard AuthKit redirects

### DIFF
--- a/apps/dashboard/app/(dashboard)/account/page.tsx
+++ b/apps/dashboard/app/(dashboard)/account/page.tsx
@@ -1,5 +1,6 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { UserProfile } from "@workos-inc/widgets";
+import { redirect } from "next/navigation";
 
 import { WidgetLoadingGate } from "@/components/widget-loading-gate";
 import { WorkOsWidgetsProvider } from "@/components/workos-widgets-provider";
@@ -13,7 +14,11 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
 export default async function AccountPage() {
-  const { accessToken } = await withAuth({ ensureSignedIn: true });
+  const { accessToken, user } = await withAuth();
+
+  if (!user || !accessToken) {
+    redirect("/sign-in");
+  }
 
   return (
     <>

--- a/apps/dashboard/app/(dashboard)/agent/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agent/page.tsx
@@ -1,9 +1,15 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
 
 import { AgentCommand } from "./agent-command";
 
 export default async function AgentPage() {
-  const { user } = await withAuth({ ensureSignedIn: true });
+  const { user } = await withAuth();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
   const aiReady = Boolean(process.env.OPENAI_API_KEY);
 
   return (

--- a/apps/dashboard/app/(dashboard)/page.tsx
+++ b/apps/dashboard/app/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { withAuth } from "@workos-inc/authkit-nextjs"
+import { redirect } from "next/navigation"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -79,7 +80,12 @@ function Favicon({ domain }: { domain: string }) {
 
 
 export default async function Page() {
-  const { user } = await withAuth({ ensureSignedIn: true })
+  const { user } = await withAuth()
+
+  if (!user) {
+    redirect("/sign-in")
+  }
+
   const convex = getConvexClient()
   const recent = await convex.query(api.designRuns.listRecent, {
     userId: user.id,

--- a/apps/dashboard/app/(dashboard)/runs/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/runs/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { withAuth } from "@workos-inc/authkit-nextjs"
@@ -21,7 +21,12 @@ export default async function RunPage({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  const { user } = await withAuth({ ensureSignedIn: true })
+  const { user } = await withAuth()
+
+  if (!user) {
+    redirect("/sign-in")
+  }
+
   const convex = getConvexClient()
   const run = await convex.query(api.designRuns.get, {
     id: slug as Id<"designRuns">,

--- a/apps/dashboard/app/(dashboard)/team/page.tsx
+++ b/apps/dashboard/app/(dashboard)/team/page.tsx
@@ -1,5 +1,6 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { UsersManagement } from "@workos-inc/widgets";
+import { redirect } from "next/navigation";
 
 import { WidgetLoadingGate } from "@/components/widget-loading-gate";
 import { WorkOsWidgetsProvider } from "@/components/workos-widgets-provider";
@@ -13,9 +14,11 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
 export default async function TeamPage() {
-  const { accessToken, organizationId } = await withAuth({
-    ensureSignedIn: true,
-  });
+  const { accessToken, organizationId, user } = await withAuth();
+
+  if (!user || !accessToken) {
+    redirect("/sign-in");
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

<!-- What does this change? 1-3 bullets. Link the issue. -->

- 
- 

Closes #

## Surface(s) affected

- [ ] Web (`apps/web`)
- [ ] HTTP API (`apps/api`)
- [ ] CLI (`apps/cli`)
- [ ] SDK (`packages/sdk`)
- [ ] Agent skill (`skills/getdesign`)
- [ ] Shared package (`agent` / `tools` / `types` / `ui` / `config`)
- [ ] Convex (`convex/`)
- [ ] Repo tooling / docs

## Breaking changes?

- [ ] No
- [ ] Yes — migration notes:

## Screenshots / output samples

<!-- Web UI: before + after screenshots.
     Skill / SDK / CLI / API: paste the relevant `design.md` fragment or response body. -->

## Checklist

- [ ] Conventional-commit title (e.g. `feat(skill): …`)
- [ ] `bun run lint` passes
- [ ] `bun run typecheck` passes
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] If this changes the 9-section `design.md` contract, a maintainer has approved the schema change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication flow handling across multiple dashboard pages to strengthen access control verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MohtashamMurshid/getdesign/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->