### PR TITLE
feat(dashboard): API, CLI, and SDK developer surface pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 
 ### Added
 
+- **[dashboard]** API, CLI, SDK, Skills, Docs, and Support pages with marketing-style animated demos, copy-paste quickstarts, and links to `docs.getdesign.app`. Documents that v1 has no getdesign API key; full runs use BYOK Daytona/OpenAI credentials.
+- **[content]** New `@getdesign/content` package for shared demo sites, surface metadata, docs URLs, and snippet builders (used by dashboard, web, and video).
 - **[tools]** `@getdesign/tools` now ships concrete `crawler`, `extractors`, `render`, and `daytona` modules with deterministic URL/CSS resolution, token extraction, markdown rendering, and typed Daytona helpers.
 - **[infra]** `infra/daytona/Dockerfile` and `infra/daytona/README.md` define the first in-repo Daytona snapshot for Chromium + computer-use flows.
 - **[skill]** New fifth surface: portable `SKILL.md` at `skills/getdesign/` that reproduces the 9-section `design.md` contract using any coding agent's built-in tools (WebFetch, browser, file write). Installable via `npx skills add MohtashamMurshid/getdesign`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -20,19 +20,21 @@ Before changing code in a workspace, read that workspace’s `**CONTEXT.md*`*. E
 | **studio-site** | `[apps/studio-site/CONTEXT.md](apps/studio-site/CONTEXT.md)` | Studio marketing / web — Next.js                 |
 | **video**       | `[apps/video/CONTEXT.md](apps/video/CONTEXT.md)`             | Video app / asset pipeline                       |
 | **web**         | `[apps/web/CONTEXT.md](apps/web/CONTEXT.md)`                 | Main product web — Next.js + Convex              |
+| **dashboard**   | `[apps/dashboard/CONTEXT.md](apps/dashboard/CONTEXT.md)`     | Authenticated product dashboard — Next.js + WorkOS |
 
 
 ## Packages
 
 
-| Context    | CONTEXT.md path                                            | Scope                                                |
-| ---------- | ---------------------------------------------------------- | ---------------------------------------------------- |
-| **agent**  | `[packages/agent/CONTEXT.md](packages/agent/CONTEXT.md)`   | Coordinator + sub-agents — URL → validated DesignDoc |
-| **cli**    | `[packages/cli/CONTEXT.md](packages/cli/CONTEXT.md)`       | CLI (planned)                                        |
-| **config** | `[packages/config/CONTEXT.md](packages/config/CONTEXT.md)` | Shared TS / tooling config for workspaces            |
-| **sdk**    | `[packages/sdk/CONTEXT.md](packages/sdk/CONTEXT.md)`       | TypeScript SDK (planned)                             |
-| **tools**  | `[packages/tools/CONTEXT.md](packages/tools/CONTEXT.md)`   | Shared extraction / tool surface                     |
-| **types**  | `[packages/types/CONTEXT.md](packages/types/CONTEXT.md)`   | Shared types, schemas — DesignDoc, tokens, etc.      |
+| Context     | CONTEXT.md path                                              | Scope                                                |
+| ----------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| **agent**   | `[packages/agent/CONTEXT.md](packages/agent/CONTEXT.md)`     | Coordinator + sub-agents — URL → validated DesignDoc |
+| **cli**     | `[packages/cli/CONTEXT.md](packages/cli/CONTEXT.md)`         | CLI (planned)                                        |
+| **config**  | `[packages/config/CONTEXT.md](packages/config/CONTEXT.md)`   | Shared TS / tooling config for workspaces            |
+| **content** | `[packages/content/CONTEXT.md](packages/content/CONTEXT.md)` | Shared demo sites, surface meta, snippet builders    |
+| **sdk**     | `[packages/sdk/CONTEXT.md](packages/sdk/CONTEXT.md)`         | TypeScript SDK (planned)                             |
+| **tools**   | `[packages/tools/CONTEXT.md](packages/tools/CONTEXT.md)`     | Shared extraction / tool surface                     |
+| **types**   | `[packages/types/CONTEXT.md](packages/types/CONTEXT.md)`     | Shared types, schemas — DesignDoc, tokens, etc.      |
 
 
 ## Root (optional)

--- a/apps/dashboard/CONTEXT.md
+++ b/apps/dashboard/CONTEXT.md
@@ -1,0 +1,9 @@
+# dashboard
+
+Authenticated product dashboard (Next.js + WorkOS AuthKit).
+
+## Terms
+
+- **Surface page** — in-app docs + animated preview for API, CLI, SDK, or Skills.
+- **Developer kit** — shared UI under `components/developer/` for surface pages.
+- **Credential callout** — docs-only note that v1 has no getdesign API key; BYOK uses Daytona/OpenAI.

--- a/apps/dashboard/app/(dashboard)/agent/agent-command.tsx
+++ b/apps/dashboard/app/(dashboard)/agent/agent-command.tsx
@@ -70,7 +70,7 @@ export function AgentCommand({ aiReady, user }: AgentCommandProps) {
         className="px-0 pb-0"
         status={isPending || isRunning ? "submitted" : "ready"}
         disabled={!aiReady || isRunning}
-        placeholder={aiReady ? "Enter a URL..." : "Add an AI key to start"}
+        placeholder={aiReady ? "Enter a URL..." : "Server AI key not configured"}
         onStop={() => {}}
         onSend={({ content }) => {
           setError(null);
@@ -113,10 +113,11 @@ export function AgentCommand({ aiReady, user }: AgentCommandProps) {
           !aiReady
             ? {
                 title: "Setup needed.",
-                description: "Add an AI key in Settings.",
+                description:
+                  "This deployment needs an AI key. For local CLI/SDK/API runs, see BYOK docs.",
                 action: {
-                  label: "Settings",
-                  onClick: () => router.push("/account"),
+                  label: "API docs",
+                  onClick: () => router.push("/api"),
                 },
               }
             : undefined

--- a/apps/dashboard/app/(dashboard)/api/page.tsx
+++ b/apps/dashboard/app/(dashboard)/api/page.tsx
@@ -1,0 +1,156 @@
+import {
+  buildCurlExample,
+  docsUrl,
+} from "@getdesign/content";
+
+import {
+  CopyCommand,
+  CredentialCallout,
+  DocsLinkCard,
+  SurfaceDemo,
+  SurfacePageShell,
+} from "@/components/developer";
+
+const EXAMPLE_SITE = "https://stripe.com";
+
+export default function ApiPage() {
+  return (
+    <SurfacePageShell
+      title="API"
+      description="Turn any public URL into a design.md over HTTP. One endpoint, markdown out."
+      demo={<SurfaceDemo surface="api" />}
+    >
+      <CredentialCallout variant="api" />
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Quick start</h2>
+        <CopyCommand
+          label="curl"
+          command={buildCurlExample(EXAMPLE_SITE)}
+        />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Endpoints</h2>
+        <div className="overflow-hidden rounded-xl border text-sm">
+          <EndpointRow
+            method="GET"
+            path="/?url=…"
+            note="Markdown compatibility route"
+          />
+          <EndpointRow
+            method="GET"
+            path="/v1/design?url=…"
+            note="Markdown, or JSON with format=json"
+          />
+          <EndpointRow
+            method="GET"
+            path="/v1/design/stream?url=…"
+            note="SSE: progress, then result or error"
+            last
+          />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Query parameters</h2>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+              url
+            </code>{" "}
+            — required absolute HTTPS URL
+          </li>
+          <li>
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+              viewport
+            </code>{" "}
+            — optional, e.g.{" "}
+            <code className="font-mono text-xs">1440x900</code>
+          </li>
+          <li>
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+              format=json
+            </code>{" "}
+            — structured result on{" "}
+            <code className="font-mono text-xs">/v1/design</code>
+          </li>
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Authentication</h2>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>No getdesign API key in v1 — public calls need no Bearer token.</li>
+          <li>
+            Optional BYOK headers for full capture:{" "}
+            <code className="font-mono text-xs text-foreground">
+              x-daytona-api-key
+            </code>
+            ,{" "}
+            <code className="font-mono text-xs text-foreground">
+              x-openai-api-key
+            </code>
+            . Never put secrets in the query string.
+          </li>
+          <li>
+            Optional:{" "}
+            <code className="font-mono text-xs text-foreground">
+              x-getdesign-mode: text_only
+            </code>{" "}
+            after a capture failure.
+          </li>
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Docs</h2>
+        <div className="grid gap-2">
+          <DocsLinkCard
+            href={docsUrl("/surfaces/api")}
+            title="API surface"
+            description="Endpoint contract, params, and response codes"
+          />
+          <DocsLinkCard
+            href={docsUrl("/guides/call-the-api")}
+            title="Call the API"
+            description="Copy-paste curl walkthrough"
+          />
+          <DocsLinkCard
+            href={docsUrl("/resources/faq")}
+            title="FAQ"
+            description="Rate limits, auth model, and common questions"
+          />
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}
+
+function EndpointRow({
+  method,
+  path,
+  note,
+  last = false,
+}: {
+  method: string;
+  path: string;
+  note: string;
+  last?: boolean;
+}) {
+  return (
+    <div
+      className={`flex flex-col gap-0.5 px-4 py-3 sm:flex-row sm:items-baseline sm:gap-3 ${last ? "" : "border-b"}`}
+    >
+      <span className="shrink-0 font-mono text-xs font-medium text-foreground">
+        {method}
+      </span>
+      <code className="min-w-0 break-all font-mono text-xs text-foreground">
+        {path}
+      </code>
+      <span className="text-xs text-muted-foreground sm:ml-auto sm:text-right">
+        {note}
+      </span>
+    </div>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/cli/page.tsx
+++ b/apps/dashboard/app/(dashboard)/cli/page.tsx
@@ -1,0 +1,109 @@
+import { buildCliCommand, docsUrl } from "@getdesign/content";
+
+import {
+  CopyCommand,
+  CredentialCallout,
+  DocsLinkCard,
+  SurfaceDemo,
+  SurfacePageShell,
+} from "@/components/developer";
+
+const EXAMPLE_SITE = "https://cursor.com";
+
+export default function CliPage() {
+  return (
+    <SurfacePageShell
+      title="CLI"
+      description="Generate a Cursor-ready design.md from your terminal with bunx @getdesign/cli."
+      demo={<SurfaceDemo surface="cli" />}
+    >
+      <CredentialCallout variant="cli" />
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Install / run</h2>
+        <CopyCommand
+          label="Bun (recommended)"
+          command={buildCliCommand(EXAMPLE_SITE)}
+        />
+        <CopyCommand
+          label="npx"
+          command={`npx @getdesign/cli ${EXAMPLE_SITE}`}
+        />
+        <p className="text-xs text-muted-foreground">
+          The binary targets Bun. Install Bun first if{" "}
+          <code className="font-mono">bunx</code> is unavailable.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Output</h2>
+        <p className="text-sm text-muted-foreground">
+          Without{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+            --out
+          </code>
+          , the CLI writes to{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+            ./getdesign-runs/&lt;slug&gt;/design.md
+          </code>
+          .
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Common flags</h2>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>
+            <code className="font-mono text-xs text-foreground">--out &lt;path&gt;</code>{" "}
+            — write markdown to a file or directory
+          </li>
+          <li>
+            <code className="font-mono text-xs text-foreground">
+              --site-name &lt;name&gt;
+            </code>{" "}
+            — override detected site name
+          </li>
+          <li>
+            <code className="font-mono text-xs text-foreground">
+              --text-only-fallback
+            </code>{" "}
+            — continue with CSS/text-only if capture fails
+          </li>
+          <li>
+            <code className="font-mono text-xs text-foreground">
+              --daytona-api-key
+            </code>{" "}
+            /{" "}
+            <code className="font-mono text-xs text-foreground">
+              --openai-api-key
+            </code>{" "}
+            — or set{" "}
+            <code className="font-mono text-xs text-foreground">
+              DAYTONA_API_KEY
+            </code>{" "}
+            /{" "}
+            <code className="font-mono text-xs text-foreground">
+              OPENAI_API_KEY
+            </code>
+          </li>
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Docs</h2>
+        <div className="grid gap-2">
+          <DocsLinkCard
+            href={docsUrl("/surfaces/cli")}
+            title="CLI surface"
+            description="Usage overview and examples"
+          />
+          <DocsLinkCard
+            href={docsUrl("/reference/cli")}
+            title="CLI reference"
+            description="Generated from --help"
+          />
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/docs/page.tsx
+++ b/apps/dashboard/app/(dashboard)/docs/page.tsx
@@ -1,0 +1,112 @@
+import { DOCS_BASE_URL, docsUrl } from "@getdesign/content";
+
+import {
+  DocsLinkCard,
+  SurfacePageShell,
+} from "@/components/developer";
+
+const LINKS = [
+  {
+    href: docsUrl("/"),
+    title: "Documentation home",
+    description: "Start here — overview of getdesign",
+  },
+  {
+    href: docsUrl("/quickstart"),
+    title: "Quickstart",
+    description: "First design.md in a few minutes",
+  },
+  {
+    href: docsUrl("/surfaces/api"),
+    title: "API",
+    description: "HTTP endpoint at api.getdesign.app",
+  },
+  {
+    href: docsUrl("/surfaces/cli"),
+    title: "CLI",
+    description: "bunx @getdesign/cli",
+  },
+  {
+    href: docsUrl("/surfaces/sdk"),
+    title: "SDK",
+    description: "@getdesign/sdk typed client",
+  },
+  {
+    href: docsUrl("/surfaces/skill"),
+    title: "Skill",
+    description: "Agent skill for Cursor / Claude Code / Codex",
+  },
+  {
+    href: docsUrl("/guides/call-the-api"),
+    title: "Guide: call the API",
+    description: "curl examples and response shapes",
+  },
+  {
+    href: docsUrl("/guides/sdk-in-next"),
+    title: "Guide: SDK in Next.js",
+    description: "Route handler with streamDesign",
+  },
+  {
+    href: docsUrl("/reference/sdk"),
+    title: "SDK reference",
+    description: "TypeDoc API reference",
+  },
+  {
+    href: docsUrl("/resources/faq"),
+    title: "FAQ",
+    description: "Auth, rate limits, and common questions",
+  },
+] as const;
+
+function DocsHubVisual() {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <div className="flex items-center gap-3 border-b bg-muted/40 px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <span className="size-2.5 rounded-full bg-red-400/80" />
+          <span className="size-2.5 rounded-full bg-amber-400/80" />
+          <span className="size-2.5 rounded-full bg-emerald-400/80" />
+        </div>
+        <div className="min-w-0 flex-1 truncate rounded-md border bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
+          docs.getdesign.app
+        </div>
+      </div>
+      <div className="space-y-4 px-5 py-6">
+        <div>
+          <p className="text-lg font-semibold tracking-tight">Documentation</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Full guides and reference live on the docs site. Use the links on
+            the right — or open the hub directly.
+          </p>
+        </div>
+        <a
+          href={DOCS_BASE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center rounded-md border bg-muted/40 px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+        >
+          Open docs.getdesign.app →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function DocsPage() {
+  return (
+    <SurfacePageShell
+      title="Docs"
+      description="Curated links into docs.getdesign.app — quickstart, surfaces, guides, and reference."
+      demo={<DocsHubVisual />}
+    >
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Browse</h2>
+        <div className="grid gap-2">
+          {LINKS.map((link) => (
+            <DocsLinkCard key={link.href} {...link} />
+          ))}
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/sdk/page.tsx
+++ b/apps/dashboard/app/(dashboard)/sdk/page.tsx
@@ -1,0 +1,75 @@
+import { buildSdkInstall, docsUrl } from "@getdesign/content";
+
+import {
+  CopyCommand,
+  CredentialCallout,
+  DocsLinkCard,
+  SurfaceDemo,
+  SurfacePageShell,
+} from "@/components/developer";
+import { SdkSnippetTabs } from "@/components/developer/sdk-snippet-tabs";
+
+export default function SdkPage() {
+  return (
+    <SurfacePageShell
+      title="SDK"
+      description="Typed TypeScript client for Node/Bun. getDesign and streamDesign run the agent in-process with your credentials."
+      demo={<SurfaceDemo surface="sdk" />}
+    >
+      <CredentialCallout variant="sdk" />
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Install</h2>
+        <CopyCommand label="package" command={buildSdkInstall()} />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Quick example</h2>
+        <SdkSnippetTabs />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Credentials</h2>
+        <p className="text-sm text-muted-foreground">
+          Pass{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+            {"credentials: { daytonaApiKey, openaiApiKey }"}
+          </code>{" "}
+          or set the same env vars the CLI uses. The SDK does not call the
+          hosted HTTP API today — it runs{" "}
+          <code className="font-mono text-xs">@getdesign/agent</code>{" "}
+          in-process.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Runtime</h2>
+        <p className="text-sm text-muted-foreground">
+          Bun/server environments with enough time for browser capture and LLM
+          synthesis. Not a browser or edge-runtime client.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Docs</h2>
+        <div className="grid gap-2">
+          <DocsLinkCard
+            href={docsUrl("/surfaces/sdk")}
+            title="SDK surface"
+            description="Install, getDesign, and streamDesign"
+          />
+          <DocsLinkCard
+            href={docsUrl("/guides/sdk-in-next")}
+            title="SDK in Next.js"
+            description="Route-handler pattern with streamDesign"
+          />
+          <DocsLinkCard
+            href={docsUrl("/reference/sdk")}
+            title="SDK reference"
+            description="TypeDoc-generated API reference"
+          />
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/skills/page.tsx
+++ b/apps/dashboard/app/(dashboard)/skills/page.tsx
@@ -1,0 +1,98 @@
+import { SKILL_INSTALL_CMD, docsUrl } from "@getdesign/content";
+
+import {
+  CopyCommand,
+  DocsLinkCard,
+  SurfacePageShell,
+} from "@/components/developer";
+
+function SkillDemo() {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <div className="flex items-center gap-3 border-b bg-muted/40 px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <span className="size-2.5 rounded-full bg-red-400/80" />
+          <span className="size-2.5 rounded-full bg-amber-400/80" />
+          <span className="size-2.5 rounded-full bg-emerald-400/80" />
+        </div>
+        <div className="min-w-0 flex-1 truncate rounded-md border bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
+          claude-code · skill: getdesign
+        </div>
+      </div>
+      <div className="space-y-3 px-4 py-5 font-mono text-[12.5px] leading-relaxed">
+        <p className="text-muted-foreground">
+          <span className="tok-com"># Install once, then ask your agent</span>
+        </p>
+        <p>
+          <span className="text-muted-foreground">$</span>{" "}
+          <span className="text-foreground">{SKILL_INSTALL_CMD}</span>
+        </p>
+        <p className="text-muted-foreground">
+          <span className="tok-com">✓</span> skill registered · getdesign
+        </p>
+        <pre className="m-0 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 text-foreground">
+          <span className="tok-key">You</span>
+          {"\n"}
+          Match this landing page to cursor.com
+          {"\n\n"}
+          <span className="tok-key">Agent</span>
+          {"\n"}
+          Using skill <span className="tok-str">getdesign</span>…
+          {"\n"}
+          Writing <span className="tok-str">design.md</span>
+          <span className="caret" />
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export default function SkillsPage() {
+  return (
+    <SurfacePageShell
+      title="Skills"
+      description="Install getdesign as an agent skill so Cursor, Claude Code, or Codex can pull a design.md into context."
+      demo={<SkillDemo />}
+    >
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Install</h2>
+        <CopyCommand label="skills.sh" command={SKILL_INSTALL_CMD} />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Use it</h2>
+        <p className="text-sm text-muted-foreground">
+          After install, ask your coding agent to match a brand or generate a
+          design system from a URL. The skill uses the same agent core as the
+          API, CLI, and SDK.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Guides</h2>
+        <div className="grid gap-2">
+          <DocsLinkCard
+            href={docsUrl("/surfaces/skill")}
+            title="Skill surface"
+            description="What the skill does and how it fits the five surfaces"
+          />
+          <DocsLinkCard
+            href={docsUrl("/guides/use-with-cursor")}
+            title="Use with Cursor"
+            description="Wire getdesign into Cursor Agent"
+          />
+          <DocsLinkCard
+            href={docsUrl("/guides/use-with-claude-code")}
+            title="Use with Claude Code"
+            description="Skill install and prompt patterns"
+          />
+          <DocsLinkCard
+            href={docsUrl("/guides/use-with-codex")}
+            title="Use with Codex"
+            description="Codex-specific setup"
+          />
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/support/page.tsx
+++ b/apps/dashboard/app/(dashboard)/support/page.tsx
@@ -1,0 +1,63 @@
+import { SITE_GITHUB_URL, docsUrl } from "@getdesign/content";
+
+import {
+  DocsLinkCard,
+  SurfacePageShell,
+} from "@/components/developer";
+
+function SupportVisual() {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <div className="border-b bg-muted/40 px-4 py-3">
+        <p className="text-sm font-medium">How can we help?</p>
+      </div>
+      <div className="space-y-3 px-4 py-5 text-sm text-muted-foreground">
+        <p>
+          Start with the FAQ and docs. For bugs or feature requests, open a
+          GitHub issue on the public repo.
+        </p>
+        <p>
+          Account and team settings live under Settings in the sidebar — WorkOS
+          handles profile and organization membership.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function SupportPage() {
+  return (
+    <SurfacePageShell
+      title="Support"
+      description="Docs, FAQ, and the public issue tracker."
+      demo={<SupportVisual />}
+    >
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Resources</h2>
+        <div className="grid gap-2">
+          <DocsLinkCard
+            href={docsUrl("/resources/faq")}
+            title="FAQ"
+            description="Auth model, rate limits, and common questions"
+          />
+          <DocsLinkCard
+            href={docsUrl("/")}
+            title="Documentation"
+            description="Quickstart, surfaces, and guides"
+          />
+          <DocsLinkCard
+            href={`${SITE_GITHUB_URL}/issues`}
+            title="GitHub Issues"
+            description="Report a bug or request a feature"
+          />
+          <DocsLinkCard
+            href="/account"
+            title="Account settings"
+            description="WorkOS profile and security"
+            external={false}
+          />
+        </div>
+      </section>
+    </SurfacePageShell>
+  );
+}

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -131,3 +131,37 @@
     @apply font-sans;
     }
 }
+
+/* Developer surface demos — syntax tokens + playback motion */
+@keyframes fade-in-up {
+  0% { opacity: 0; transform: translateY(6px); filter: blur(2px); }
+  100% { opacity: 1; transform: translateY(0); filter: blur(0); }
+}
+@keyframes caret-blink {
+  50% { opacity: 0; }
+}
+.fade-in-up {
+  animation: fade-in-up 320ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+.caret::after {
+  content: "▍";
+  color: var(--foreground);
+  margin-left: 2px;
+  animation: caret-blink 1.1s steps(1) infinite;
+}
+.tok-key { color: #7c3aed; }
+.tok-str { color: #15803d; }
+.tok-fn  { color: #2563eb; }
+.tok-num { color: #b45309; }
+.tok-com { color: var(--muted-foreground); }
+.tok-var { color: #be185d; }
+.tok-punc { color: var(--muted-foreground); }
+.dark .tok-key { color: #c084fc; }
+.dark .tok-str { color: #a3e635; }
+.dark .tok-fn  { color: #60a5fa; }
+.dark .tok-num { color: #fbbf24; }
+.dark .tok-var { color: #f472b6; }
+@media (prefers-reduced-motion: reduce) {
+  .fade-in-up { animation: none; }
+  .caret::after { animation: none; }
+}

--- a/apps/dashboard/components/developer/copy-command.tsx
+++ b/apps/dashboard/components/developer/copy-command.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+type CopyCommandProps = {
+  command: string;
+  label?: string;
+  className?: string;
+};
+
+export function CopyCommand({ command, label, className }: CopyCommandProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // ignore clipboard errors
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {label ? (
+        <div className="text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+          {label}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="group flex w-full items-start gap-3 rounded-lg border bg-muted/40 px-3.5 py-2.5 text-left font-mono text-[13px] transition-colors hover:bg-muted"
+      >
+        <span className="shrink-0 text-muted-foreground">$</span>
+        <span className="min-w-0 flex-1 whitespace-pre-wrap break-all text-foreground">
+          {command}
+        </span>
+        <span className="shrink-0 rounded-md border bg-background px-2 py-[3px] text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground group-hover:text-foreground">
+          {copied ? "copied" : "copy"}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/credential-callout.tsx
+++ b/apps/dashboard/components/developer/credential-callout.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { docsUrl } from "@getdesign/content";
+
+import { cn } from "@/lib/utils";
+
+type CredentialCalloutProps = {
+  variant?: "api" | "cli" | "sdk";
+  className?: string;
+};
+
+const COPY: Record<
+  NonNullable<CredentialCalloutProps["variant"]>,
+  { title: string; body: string }
+> = {
+  api: {
+    title: "No getdesign API key yet",
+    body: "Public v1 calls need no getdesign auth. For full visual capture with your own infra, pass Daytona and OpenAI keys in request headers — never in query strings.",
+  },
+  cli: {
+    title: "Bring your own keys",
+    body: "The CLI runs the agent on your machine. Set DAYTONA_API_KEY and OPENAI_API_KEY (or pass --daytona-api-key / --openai-api-key).",
+  },
+  sdk: {
+    title: "Bring your own keys",
+    body: "The SDK runs in-process today. Pass credentials: { daytonaApiKey, openaiApiKey } (or rely on the same env vars as the CLI).",
+  },
+};
+
+export function CredentialCallout({
+  variant = "api",
+  className,
+}: CredentialCalloutProps) {
+  const content = COPY[variant];
+
+  return (
+    <aside
+      className={cn(
+        "rounded-xl border border-amber-500/25 bg-amber-500/5 px-4 py-3",
+        className,
+      )}
+    >
+      <p className="text-sm font-medium text-foreground">{content.title}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{content.body}</p>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Details in{" "}
+        <Link
+          href={docsUrl("/resources/faq")}
+          target="_blank"
+          rel="noreferrer"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          the FAQ
+        </Link>
+        .
+      </p>
+    </aside>
+  );
+}

--- a/apps/dashboard/components/developer/demo-chrome.tsx
+++ b/apps/dashboard/components/developer/demo-chrome.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DemoChromeProps = {
+  label: string;
+  children: ReactNode;
+  className?: string;
+  footer?: ReactNode;
+};
+
+export function DemoChrome({
+  label,
+  children,
+  className,
+  footer,
+}: DemoChromeProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border bg-card shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3 border-b bg-muted/40 px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <span className="size-2.5 rounded-full bg-red-400/80" />
+          <span className="size-2.5 rounded-full bg-amber-400/80" />
+          <span className="size-2.5 rounded-full bg-emerald-400/80" />
+        </div>
+        <div className="min-w-0 flex-1 truncate rounded-md border bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
+          {label}
+        </div>
+      </div>
+      <div className="min-h-[280px]">{children}</div>
+      {footer ? (
+        <div className="border-t px-4 py-2.5 text-xs text-muted-foreground">
+          {footer}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/docs-link-card.tsx
+++ b/apps/dashboard/components/developer/docs-link-card.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+type DocsLinkCardProps = {
+  href: string;
+  title: string;
+  description: string;
+  external?: boolean;
+  className?: string;
+};
+
+export function DocsLinkCard({
+  href,
+  title,
+  description,
+  external = true,
+  className,
+}: DocsLinkCardProps) {
+  return (
+    <Link
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noreferrer" : undefined}
+      className={cn(
+        "block rounded-xl border px-4 py-3 transition-colors hover:bg-muted/40",
+        className,
+      )}
+    >
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+    </Link>
+  );
+}

--- a/apps/dashboard/components/developer/index.ts
+++ b/apps/dashboard/components/developer/index.ts
@@ -1,0 +1,6 @@
+export { CopyCommand } from "./copy-command";
+export { CredentialCallout } from "./credential-callout";
+export { DemoChrome } from "./demo-chrome";
+export { DocsLinkCard } from "./docs-link-card";
+export { SurfaceDemo } from "./surface-demo";
+export { SurfacePageShell } from "./surface-page-shell";

--- a/apps/dashboard/components/developer/previews/api-preview.tsx
+++ b/apps/dashboard/components/developer/previews/api-preview.tsx
@@ -1,0 +1,73 @@
+import type { DemoSite } from "@getdesign/content";
+
+type ApiPreviewProps = {
+  site: DemoSite;
+  visibleSteps: number;
+  done: boolean;
+};
+
+export function ApiPreview({ site, visibleSteps, done }: ApiPreviewProps) {
+  return (
+    <div className="px-4 py-4 font-mono text-[12.5px] leading-relaxed">
+      <div className="fade-in-up">
+        <div className="text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+          request
+        </div>
+        <pre className="m-0 mt-2 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-[12.5px] leading-relaxed text-foreground">
+          <span className="tok-key">GET</span>{" "}
+          <span className="tok-str">
+            https://api.getdesign.app/?url={site.url}
+          </span>
+          {"\n"}
+          <span className="tok-com">Accept: text/markdown</span>
+        </pre>
+      </div>
+
+      {visibleSteps >= 2 ? (
+        <div className="fade-in-up mt-5">
+          <div className="flex items-center gap-2 text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+            response
+            <span className="rounded-[3px] border px-1 py-[1px] text-[9.5px] text-foreground">
+              {done ? "200 OK" : "200 streaming"}
+            </span>
+          </div>
+          <pre className="m-0 mt-2 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-[12.5px] leading-relaxed text-muted-foreground">
+            <span className="tok-com"># {site.url}</span>
+            {"\n\n"}
+            {visibleSteps >= 2 ? (
+              <>
+                <span className="tok-key">## Visual Theme</span>
+                {"\n"}
+                <span className="text-foreground">{site.theme}.</span>
+                {"\n\n"}
+              </>
+            ) : null}
+            {visibleSteps >= 5 ? (
+              <>
+                <span className="tok-key">## Palette</span>
+                {"\n"}
+                {site.palette.map((color) => (
+                  <span key={color}>
+                    - <span className="tok-str">{color}</span>
+                    {"\n"}
+                  </span>
+                ))}
+                {"\n"}
+                <span className="tok-key">## Typography</span>
+                {"\n"}
+                - display: <span className="tok-str">{site.fonts[0]}</span>
+                {"\n"}
+                - mono: <span className="tok-str">{site.fonts[1]}</span>
+                {"\n"}
+              </>
+            ) : null}
+            {done ? (
+              <span className="tok-com">{"\n"}… +5 sections · 14.3KB total</span>
+            ) : null}
+            <span className="caret" />
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/previews/cli-preview.tsx
+++ b/apps/dashboard/components/developer/previews/cli-preview.tsx
@@ -1,0 +1,69 @@
+import type { DemoSite } from "@getdesign/content";
+
+type CliPreviewProps = {
+  site: DemoSite;
+  visibleSteps: number;
+  done: boolean;
+};
+
+export function CliPreview({ site, visibleSteps, done }: CliPreviewProps) {
+  return (
+    <div className="bg-background px-4 py-4 font-mono text-[12.5px] leading-relaxed">
+      <div className="fade-in-up">
+        <span className="text-muted-foreground">$</span>{" "}
+        <span className="text-foreground">npx @getdesign/cli {site.url}</span>
+      </div>
+
+      {visibleSteps >= 1 ? (
+        <div className="fade-in-up mt-2 text-muted-foreground">
+          <span className="tok-com">↳ getdesign v0.1.0 · streaming to stdout</span>
+        </div>
+      ) : null}
+
+      {visibleSteps >= 2 ? (
+        <div className="fade-in-up mt-3 text-muted-foreground">
+          <span className="tok-com">✓</span> crawled html + 4 stylesheets
+          <span className="text-muted-foreground/70"> 128ms</span>
+        </div>
+      ) : null}
+
+      {visibleSteps >= 4 ? (
+        <div className="fade-in-up text-muted-foreground">
+          <span className="tok-com">✓</span> screenshot 1440×900
+          <span className="text-muted-foreground/70"> 1.2MB</span>
+        </div>
+      ) : null}
+
+      {visibleSteps >= 6 ? (
+        <div className="fade-in-up text-muted-foreground">
+          <span className="tok-com">✓</span> extracted 14 tokens · 4 palette · 2
+          fonts
+        </div>
+      ) : null}
+
+      {visibleSteps >= 7 ? (
+        <pre className="fade-in-up m-0 mt-3 whitespace-pre-wrap break-words font-mono text-[12.5px] leading-relaxed text-foreground">
+          <span className="tok-key"># {site.url}</span>
+          {"\n"}
+          <span className="text-muted-foreground">
+            ## Visual Theme{"\n"}
+            {site.theme}.{"\n\n"}
+            ## Palette{"\n"}
+            {site.palette.map((color) => `- ${color}\n`).join("")}
+          </span>
+          <span className="caret" />
+        </pre>
+      ) : null}
+
+      {done ? (
+        <div className="fade-in-up mt-4 whitespace-pre-wrap text-muted-foreground">
+          <span className="tok-com">✓</span> wrote{" "}
+          <span className="tok-str">design.md</span>{" "}
+          <span className="text-muted-foreground/70">14.3KB · 8.2s</span>
+          {"\n"}
+          <span className="text-muted-foreground">$</span> <span className="caret" />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/previews/sdk-preview.tsx
+++ b/apps/dashboard/components/developer/previews/sdk-preview.tsx
@@ -1,0 +1,81 @@
+import type { DemoSite } from "@getdesign/content";
+
+type SdkPreviewProps = {
+  site: DemoSite;
+  visibleSteps: number;
+  done: boolean;
+};
+
+export function SdkPreview({ site, visibleSteps, done }: SdkPreviewProps) {
+  return (
+    <div className="px-4 py-4 font-mono text-[12.5px] leading-relaxed">
+      <div className="fade-in-up">
+        <div className="text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+          app.ts
+        </div>
+        <pre className="m-0 mt-2 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-[12.5px] leading-relaxed text-foreground">
+          <span className="tok-key">import</span>{" "}
+          <span className="text-foreground">{"{ streamDesign }"}</span>{" "}
+          <span className="tok-key">from</span>{" "}
+          <span className="tok-str">&quot;@getdesign/sdk&quot;</span>;{"\n"}
+          {"\n"}
+          <span className="tok-key">const</span>{" "}
+          <span className="text-foreground">stream</span> ={" "}
+          <span className="tok-fn">streamDesign</span>(
+          <span className="tok-str">&quot;{site.url}&quot;</span>);{"\n"}
+          {"\n"}
+          <span className="tok-key">for await</span>{" "}
+          <span className="tok-punc">(</span>
+          <span className="tok-key">const</span>{" "}
+          <span className="text-foreground">chunk</span>{" "}
+          <span className="tok-key">of</span>{" "}
+          <span className="text-foreground">stream</span>
+          <span className="tok-punc">) {"{"}</span>
+          {"\n"}
+          {"  "}
+          <span className="text-foreground">
+            process.stdout.write(chunk);
+          </span>
+          {"\n"}
+          <span className="tok-punc">{"}"}</span>
+        </pre>
+      </div>
+
+      {visibleSteps >= 2 ? (
+        <div className="fade-in-up mt-5">
+          <div className="text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground">
+            stdout
+          </div>
+          <pre className="m-0 mt-2 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-[12.5px] leading-relaxed text-muted-foreground">
+            <span className="tok-key"># {site.url}</span>
+            {"\n\n"}
+            <span className="tok-key">## Visual Theme</span>
+            {"\n"}
+            <span className="text-foreground">{site.theme}.</span>
+            {"\n"}
+            {visibleSteps >= 5 ? (
+              <>
+                {"\n"}
+                <span className="tok-key">## Palette</span>
+                {"\n"}
+                {site.palette.map((color) => (
+                  <span key={color}>
+                    - <span className="tok-str">{color}</span>
+                    {"\n"}
+                  </span>
+                ))}
+              </>
+            ) : null}
+            {done ? (
+              <span className="tok-com">
+                {"\n"}
+                {"// stream closed · 14.3KB"}
+              </span>
+            ) : null}
+            <span className="caret" />
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/sdk-snippet-tabs.tsx
+++ b/apps/dashboard/components/developer/sdk-snippet-tabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import {
+  buildSdkGetDesignSnippet,
+  buildSdkStreamSnippet,
+} from "@getdesign/content";
+
+import { CopyCommand } from "@/components/developer/copy-command";
+import { cn } from "@/lib/utils";
+
+type Tab = "getDesign" | "streamDesign";
+
+const EXAMPLE_SITE = "https://linear.app";
+
+export function SdkSnippetTabs() {
+  const [tab, setTab] = useState<Tab>("getDesign");
+
+  const snippet =
+    tab === "getDesign"
+      ? buildSdkGetDesignSnippet(EXAMPLE_SITE)
+      : buildSdkStreamSnippet(EXAMPLE_SITE);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-1.5">
+        {(
+          [
+            ["getDesign", "getDesign"],
+            ["streamDesign", "streamDesign"],
+          ] as const
+        ).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTab(id)}
+            className={cn(
+              "rounded-md border px-2.5 py-1 font-mono text-[11px] transition-colors",
+              tab === id
+                ? "border-foreground/20 bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <CopyCommand label="TypeScript" command={snippet} />
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/surface-demo.tsx
+++ b/apps/dashboard/components/developer/surface-demo.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DEMO_SITES,
+  chromeLabel,
+  type DemoSite,
+  type SurfaceId,
+} from "@getdesign/content";
+
+import { DemoChrome } from "@/components/developer/demo-chrome";
+import { ApiPreview } from "@/components/developer/previews/api-preview";
+import { CliPreview } from "@/components/developer/previews/cli-preview";
+import { SdkPreview } from "@/components/developer/previews/sdk-preview";
+import { useDemoPlayback } from "@/components/developer/use-demo-playback";
+import { cn } from "@/lib/utils";
+
+const TOTAL_STEPS = 8;
+
+const FOOTER: Record<"api" | "cli" | "sdk", string> = {
+  api: "One GET · text/markdown out",
+  cli: "bunx @getdesign/cli · writes design.md",
+  sdk: "@getdesign/sdk · typed stream in-process",
+};
+
+type SurfaceDemoProps = {
+  surface: "api" | "cli" | "sdk";
+};
+
+function Preview({
+  surface,
+  site,
+  visibleSteps,
+  done,
+}: {
+  surface: "api" | "cli" | "sdk";
+  site: DemoSite;
+  visibleSteps: number;
+  done: boolean;
+}) {
+  switch (surface) {
+    case "api":
+      return (
+        <ApiPreview site={site} visibleSteps={visibleSteps} done={done} />
+      );
+    case "cli":
+      return (
+        <CliPreview site={site} visibleSteps={visibleSteps} done={done} />
+      );
+    case "sdk":
+      return (
+        <SdkPreview site={site} visibleSteps={visibleSteps} done={done} />
+      );
+    default: {
+      const _exhaustive: never = surface;
+      return _exhaustive;
+    }
+  }
+}
+
+function PlaybackPanel({
+  surface,
+  site,
+}: {
+  surface: "api" | "cli" | "sdk";
+  site: DemoSite;
+}) {
+  const { visibleSteps, done } = useDemoPlayback({
+    totalSteps: TOTAL_STEPS,
+  });
+
+  return (
+    <DemoChrome
+      label={chromeLabel(surface as SurfaceId, site.url)}
+      footer={FOOTER[surface]}
+    >
+      <Preview
+        surface={surface}
+        site={site}
+        visibleSteps={visibleSteps}
+        done={done}
+      />
+    </DemoChrome>
+  );
+}
+
+export function SurfaceDemo({ surface }: SurfaceDemoProps) {
+  const [siteId, setSiteId] = useState(DEMO_SITES[0]?.id ?? "cursor");
+  const [replayNonce, setReplayNonce] = useState(0);
+  const site =
+    DEMO_SITES.find((entry) => entry.id === siteId) ?? DEMO_SITES[0]!;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {DEMO_SITES.map((entry) => {
+          const active = entry.id === site.id;
+          return (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => setSiteId(entry.id)}
+              className={cn(
+                "rounded-md border px-2.5 py-1 font-mono text-[11px] transition-colors",
+                active
+                  ? "border-foreground/20 bg-muted text-foreground"
+                  : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+              )}
+            >
+              {entry.url}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => setReplayNonce((n) => n + 1)}
+          className="ml-auto rounded-md border px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+        >
+          Replay
+        </button>
+      </div>
+
+      <PlaybackPanel
+        key={`${surface}:${site.id}:${replayNonce}`}
+        surface={surface}
+        site={site}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/components/developer/surface-page-shell.tsx
+++ b/apps/dashboard/components/developer/surface-page-shell.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+type SurfacePageShellProps = {
+  title: string;
+  description: string;
+  demo: ReactNode;
+  children: ReactNode;
+};
+
+export function SurfacePageShell({
+  title,
+  description,
+  demo,
+  children,
+}: SurfacePageShellProps) {
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator
+            orientation="vertical"
+            className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+          />
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbPage>{title}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
+      </header>
+
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-8 pt-0">
+        <div className="max-w-2xl">
+          <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">{description}</p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">
+          <div className="min-w-0">{demo}</div>
+          <div className="flex min-w-0 flex-col gap-5">{children}</div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/components/developer/use-demo-playback.ts
+++ b/apps/dashboard/components/developer/use-demo-playback.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type UseDemoPlaybackOptions = {
+  totalSteps: number;
+  delay?: number;
+  startDelay?: number;
+};
+
+/**
+ * Auto-advances visibleSteps from 0 → totalSteps.
+ * Remount (via React key) to restart playback after site/surface changes.
+ */
+export function useDemoPlayback({
+  totalSteps,
+  delay = 620,
+  startDelay = 280,
+}: UseDemoPlaybackOptions) {
+  const [visibleSteps, setVisibleSteps] = useState(0);
+
+  useEffect(() => {
+    const timers: Array<ReturnType<typeof setTimeout>> = [];
+
+    const tick = (nextStep: number) => {
+      setVisibleSteps(nextStep);
+
+      if (nextStep < totalSteps) {
+        timers.push(setTimeout(() => tick(nextStep + 1), delay));
+      }
+    };
+
+    timers.push(setTimeout(() => tick(1), startDelay));
+
+    return () => {
+      for (const timer of timers) clearTimeout(timer);
+    };
+  }, [delay, startDelay, totalSteps]);
+
+  return {
+    visibleSteps,
+    done: visibleSteps >= totalSteps,
+  };
+}

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -15,6 +15,7 @@
     "@ai-sdk/react": "^3.0.180",
     "@base-ui/react": "^1.4.1",
     "@getdesign/agent": "workspace:*",
+    "@getdesign/content": "workspace:*",
     "@getdesign/sdk": "workspace:*",
     "@getdesign/tools": "workspace:*",
     "@getdesign/types": "workspace:*",

--- a/apps/video/package.json
+++ b/apps/video/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "dependencies": {
     "@elevenlabs/elevenlabs-js": "^2.44.0",
+    "@getdesign/content": "workspace:*",
     "@remotion/captions": "4.0.451",
     "@remotion/cli": "4.0.451",
     "@remotion/elevenlabs": "4.0.451",

--- a/apps/video/src/scenes/dashboard-data.ts
+++ b/apps/video/src/scenes/dashboard-data.ts
@@ -1,74 +1,22 @@
 /**
- * Mirrors `apps/web/app/_components/interactive-demo/constants.tsx` + site.ts
- * Copy is aligned with `architecture.md` (agent, API, SDK, Daytona, etc.).
+ * Re-exports shared demo constants from `@getdesign/content`, plus
+ * video-only architecture copy for Remotion scenes.
  */
 
-export type DemoSite = {
-  id: string;
-  url: string;
-  brandColor: string;
-  theme: string;
-  palette: string[];
-  fonts: [string, string];
-  sections: string[];
-};
+import {
+  DEMO_SITES,
+  DEFAULT_DEMO_SITE_ID,
+  SURFACE_META,
+  chromeLabel,
+  type DemoSite,
+  type SurfaceId,
+} from "@getdesign/content";
 
-export const DEMO_SITES: DemoSite[] = [
-  {
-    id: "cursor",
-    url: "cursor.com",
-    brandColor: "#ededed",
-    theme: "Warm minimalism meets code-editor elegance",
-    palette: ["#f2f1ed", "#26251e", "#f54e00", "#cf2d56"],
-    fonts: ["CursorGothic Display", "Berkeley Mono"],
-    sections: ["visualTheme", "palette", "typography", "components"],
-  },
-  {
-    id: "linear",
-    url: "linear.app",
-    brandColor: "#5E6AD2",
-    theme: "Hyper-precise dark UI with signal-gradient accents",
-    palette: ["#0a0a0b", "#e6e6e8", "#5e6ad2", "#ff4d6d"],
-    fonts: ["Inter Display", "Berkeley Mono"],
-    sections: ["visualTheme", "palette", "typography", "interaction"],
-  },
-  {
-    id: "stripe",
-    url: "stripe.com",
-    brandColor: "#635BFF",
-    theme: "Bright, confident, dense information architecture",
-    palette: ["#ffffff", "#0a2540", "#635bff", "#00d4ff"],
-    fonts: ["Sohne", "Sohne Mono"],
-    sections: ["visualTheme", "palette", "typography", "layout"],
-  },
-];
+export type { DemoSite, SurfaceId };
+export { DEMO_SITES, DEFAULT_DEMO_SITE_ID, chromeLabel };
 
-export type SurfaceId = "web" | "api" | "cli" | "sdk" | "skill";
-
-export const SURFACE_NAV: Array<{ id: SurfaceId; label: string }> = [
-  { id: "web", label: "web" },
-  { id: "api", label: "api" },
-  { id: "cli", label: "cli" },
-  { id: "sdk", label: "sdk" },
-  { id: "skill", label: "skill" },
-];
-
-export function chromeLabel(surface: SurfaceId, siteUrl: string): string {
-  switch (surface) {
-    case "web":
-      return "getdesign.app";
-    case "api":
-      return `api.getdesign.app/?url=${siteUrl}`;
-    case "cli":
-      return "~ · zsh";
-    case "sdk":
-      return "app.ts · @getdesign/sdk";
-    case "skill":
-      return "claude-code · skill: getdesign";
-    default:
-      return "getdesign.app";
-  }
-}
+export const SURFACE_NAV: Array<{ id: SurfaceId; label: string }> =
+  SURFACE_META.map(({ id, label }) => ({ id, label }));
 
 /** Longer explanations for the video — sourced from architecture.md + marketing copy. */
 export const SURFACE_ARCHITECTURE: Record<
@@ -119,5 +67,3 @@ export const AGENT_LAYERS = [
   "TokenExtractor - color, type, spacing, radii, and motion tokens into typed data.",
   "Synthesizer - deterministic render from structured tokens into nine-section design.md.",
 ] as const;
-
-export const DEFAULT_DEMO_SITE_ID = "stripe";

--- a/apps/web/app/_components/interactive-demo/constants.tsx
+++ b/apps/web/app/_components/interactive-demo/constants.tsx
@@ -1,51 +1,36 @@
+import type { ReactNode } from "react";
 import {
   SiCursor,
   SiLinear,
   SiStripe,
 } from "@icons-pack/react-simple-icons";
+import {
+  CHROME_LABEL_TEMPLATES,
+  DEMO_SITES,
+  SURFACE_META,
+  type DemoSite,
+} from "@getdesign/content";
 
 import type { Site, Step, Surface } from "./types";
 
-export const SITES: Site[] = [
-  {
-    id: "cursor",
-    url: "cursor.com",
-    favicon: <SiCursor className="h-full w-full" />,
-    brandColor: "#ededed",
-    theme: "Warm minimalism meets code-editor elegance",
-    palette: ["#f2f1ed", "#26251e", "#f54e00", "#cf2d56"],
-    fonts: ["CursorGothic Display", "Berkeley Mono"],
-    sections: ["visualTheme", "palette", "typography", "components"],
-  },
-  {
-    id: "linear",
-    url: "linear.app",
-    favicon: <SiLinear className="h-full w-full" />,
-    brandColor: "#5E6AD2",
-    theme: "Hyper-precise dark UI with signal-gradient accents",
-    palette: ["#0a0a0b", "#e6e6e8", "#5e6ad2", "#ff4d6d"],
-    fonts: ["Inter Display", "Berkeley Mono"],
-    sections: ["visualTheme", "palette", "typography", "interaction"],
-  },
-  {
-    id: "stripe",
-    url: "stripe.com",
-    favicon: <SiStripe className="h-full w-full" />,
-    brandColor: "#635BFF",
-    theme: "Bright, confident, dense information architecture",
-    palette: ["#ffffff", "#0a2540", "#635bff", "#00d4ff"],
-    fonts: ["Sohne", "Sohne Mono"],
-    sections: ["visualTheme", "palette", "typography", "layout"],
-  },
-];
+const FAVICONS: Record<string, ReactNode> = {
+  cursor: <SiCursor className="h-full w-full" />,
+  linear: <SiLinear className="h-full w-full" />,
+  stripe: <SiStripe className="h-full w-full" />,
+};
 
-export const SURFACES: Array<{ id: Surface; label: string; hint: string }> = [
-  { id: "web", label: "web", hint: "getdesign.app" },
-  { id: "api", label: "api", hint: "api.getdesign.app" },
-  { id: "cli", label: "cli", hint: "npx @getdesign/cli" },
-  { id: "sdk", label: "sdk", hint: "@getdesign/sdk" },
-  { id: "skill", label: "skill", hint: "skills.sh" },
-];
+function toSite(demo: DemoSite): Site {
+  return {
+    ...demo,
+    fonts: demo.fonts,
+    favicon: FAVICONS[demo.id] ?? null,
+  };
+}
+
+export const SITES: Site[] = DEMO_SITES.map(toSite);
+
+export const SURFACES: Array<{ id: Surface; label: string; hint: string }> =
+  SURFACE_META.map(({ id, label, hint }) => ({ id, label, hint }));
 
 export function buildSteps(site: Site): Step[] {
   return [
@@ -138,9 +123,5 @@ export function buildSteps(site: Site): Step[] {
 }
 
 export const CHROME_LABELS: Record<Surface, string> = {
-  web: "getdesign.app",
-  api: "api.getdesign.app/?url={url}",
-  cli: "~ · zsh",
-  sdk: "app.ts · @getdesign/sdk",
-  skill: "claude-code · skill: getdesign",
+  ...CHROME_LABEL_TEMPLATES,
 };

--- a/apps/web/app/_components/skill-install-command.tsx
+++ b/apps/web/app/_components/skill-install-command.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { SKILL_INSTALL_CMD } from "@getdesign/content";
 
-const INSTALL_CMD = "npx skills add MohtashamMurshid/getdesign";
+const INSTALL_CMD = SKILL_INSTALL_CMD;
 
 type SkillInstallCommandProps = {
   compact?: boolean;

--- a/apps/web/app/_lib/site.ts
+++ b/apps/web/app/_lib/site.ts
@@ -1,9 +1,13 @@
+import {
+  DOCS_BASE_URL,
+  SITE_GITHUB_URL as CONTENT_GITHUB_URL,
+} from "@getdesign/content";
+
 export const SITE_NAME = "getdesign";
 export const SITE_DOMAIN = "https://www.getdesign.app";
 /** Product documentation (Astro Starlight on Vercel). */
-export const SITE_DOCS_URL = "https://docs.getdesign.app";
-export const SITE_GITHUB_URL =
-  "https://github.com/MohtashamMurshid/getdesign";
+export const SITE_DOCS_URL = DOCS_BASE_URL;
+export const SITE_GITHUB_URL = CONTENT_GITHUB_URL;
 export const SITE_COPYRIGHT = "© 2026 getdesign";
 export const SITE_TAGLINE = "on-demand design systems";
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@getdesign/content": "workspace:*",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "convex": "^1.35.1",
     "next": "16.2.4",

--- a/bun.lock
+++ b/bun.lock
@@ -270,6 +270,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@getdesign/config": "workspace:*",
+        "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -1540,7 +1540,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -1964,7 +1964,7 @@
 
     "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@ai-sdk/react": "^3.0.180",
         "@base-ui/react": "^1.4.1",
         "@getdesign/agent": "workspace:*",
+        "@getdesign/content": "workspace:*",
         "@getdesign/sdk": "workspace:*",
         "@getdesign/tools": "workspace:*",
         "@getdesign/types": "workspace:*",
@@ -191,6 +192,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.44.0",
+        "@getdesign/content": "workspace:*",
         "@remotion/captions": "4.0.451",
         "@remotion/cli": "4.0.451",
         "@remotion/elevenlabs": "4.0.451",
@@ -215,6 +217,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@getdesign/content": "workspace:*",
         "@icons-pack/react-simple-icons": "^13.13.0",
         "convex": "^1.35.1",
         "next": "16.2.4",
@@ -261,6 +264,14 @@
     "packages/config": {
       "name": "@getdesign/config",
       "version": "0.1.0",
+    },
+    "packages/content": {
+      "name": "@getdesign/content",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@getdesign/config": "workspace:*",
+        "typescript": "^6.0.3",
+      },
     },
     "packages/sdk": {
       "name": "@getdesign/sdk",
@@ -700,6 +711,8 @@
     "@getdesign/cli": ["@getdesign/cli@workspace:packages/cli"],
 
     "@getdesign/config": ["@getdesign/config@workspace:packages/config"],
+
+    "@getdesign/content": ["@getdesign/content@workspace:packages/content"],
 
     "@getdesign/sdk": ["@getdesign/sdk@workspace:packages/sdk"],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf node_modules",
     "smoke:npm": "node scripts/npm-package-smoke.mjs",
-    "postinstall": "bun run --cwd ./packages/types build"
+    "postinstall": "bun run --cwd ./packages/types build && bun run --cwd ./packages/content build"
   },
   "packageManager": "bun@1.3.10",
   "engines": {

--- a/packages/content/CONTEXT.md
+++ b/packages/content/CONTEXT.md
@@ -1,0 +1,9 @@
+# @getdesign/content
+
+Framework-agnostic copy and demo constants shared by marketing, dashboard, and video.
+
+## Terms
+
+- **Demo site** — canned brand sample (url, palette, fonts, theme) used in surface previews.
+- **Surface** — one of web | api | cli | sdk | skill.
+- **Snippet builder** — pure function returning install/run/example strings for a surface.

--- a/packages/content/LICENSE
+++ b/packages/content/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 getdesign
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,0 +1,13 @@
+# @getdesign/content
+
+Shared surface metadata, demo site data, and snippet builders for marketing,
+dashboard, and video surfaces.
+
+## Exports
+
+- `DEMO_SITES` — cursor.com / linear.app / stripe.com demo metadata
+- `SURFACE_META` — labels, hints, and docs paths per surface
+- `DOCS_BASE_URL` / `docsUrl()` — docs.getdesign.app helpers
+- Snippet builders — `buildCurlExample`, `buildCliCommand`, `buildSdkSnippet`, `buildApiRequest`
+
+MIT © getdesign

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@getdesign/content",
+  "version": "0.1.0",
+  "description": "Shared surface metadata, demo sites, and snippet builders for getdesign apps.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "bun run build",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@getdesign/config": "workspace:*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@getdesign/config": "workspace:*",
+    "@types/bun": "^1.3.14",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/content/src/index.test.ts
+++ b/packages/content/src/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEMO_SITES,
+  DOCS_BASE_URL,
+  buildCliCommand,
+  buildCurlExample,
+  buildSdkInstall,
+  chromeLabel,
+  docsUrl,
+} from "./index";
+
+describe("@getdesign/content", () => {
+  test("DEMO_SITES has the three marketing brands", () => {
+    expect(DEMO_SITES.map((site) => site.id)).toEqual([
+      "cursor",
+      "linear",
+      "stripe",
+    ]);
+  });
+
+  test("docsUrl joins paths", () => {
+    expect(docsUrl()).toBe(DOCS_BASE_URL);
+    expect(docsUrl("/surfaces/api")).toBe(`${DOCS_BASE_URL}/surfaces/api`);
+  });
+
+  test("snippet builders", () => {
+    expect(buildCurlExample("stripe.com")).toContain("api.getdesign.app");
+    expect(buildCliCommand("cursor.com")).toContain("bunx @getdesign/cli");
+    expect(buildSdkInstall()).toBe("bun add @getdesign/sdk");
+  });
+
+  test("chromeLabel substitutes url for api", () => {
+    expect(chromeLabel("api", "linear.app")).toBe(
+      "api.getdesign.app/?url=linear.app",
+    );
+  });
+});

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -1,0 +1,179 @@
+export type SurfaceId = "web" | "api" | "cli" | "sdk" | "skill";
+
+export type DemoSite = {
+  id: string;
+  url: string;
+  brandColor: string;
+  theme: string;
+  palette: string[];
+  fonts: [string, string];
+  sections: string[];
+};
+
+export type SurfaceMeta = {
+  id: SurfaceId;
+  label: string;
+  hint: string;
+  docsPath: string;
+};
+
+export const DOCS_BASE_URL = "https://docs.getdesign.app";
+export const SITE_GITHUB_URL =
+  "https://github.com/MohtashamMurshid/getdesign";
+export const API_BASE_URL = "https://api.getdesign.app";
+export const SKILL_INSTALL_CMD = "npx skills add MohtashamMurshid/getdesign";
+
+export const DEMO_SITES: DemoSite[] = [
+  {
+    id: "cursor",
+    url: "cursor.com",
+    brandColor: "#ededed",
+    theme: "Warm minimalism meets code-editor elegance",
+    palette: ["#f2f1ed", "#26251e", "#f54e00", "#cf2d56"],
+    fonts: ["CursorGothic Display", "Berkeley Mono"],
+    sections: ["visualTheme", "palette", "typography", "components"],
+  },
+  {
+    id: "linear",
+    url: "linear.app",
+    brandColor: "#5E6AD2",
+    theme: "Hyper-precise dark UI with signal-gradient accents",
+    palette: ["#0a0a0b", "#e6e6e8", "#5e6ad2", "#ff4d6d"],
+    fonts: ["Inter Display", "Berkeley Mono"],
+    sections: ["visualTheme", "palette", "typography", "interaction"],
+  },
+  {
+    id: "stripe",
+    url: "stripe.com",
+    brandColor: "#635BFF",
+    theme: "Bright, confident, dense information architecture",
+    palette: ["#ffffff", "#0a2540", "#635bff", "#00d4ff"],
+    fonts: ["Sohne", "Sohne Mono"],
+    sections: ["visualTheme", "palette", "typography", "layout"],
+  },
+];
+
+export const DEFAULT_DEMO_SITE_ID = "stripe";
+
+export const SURFACE_META: SurfaceMeta[] = [
+  { id: "web", label: "web", hint: "getdesign.app", docsPath: "/surfaces/web" },
+  {
+    id: "api",
+    label: "api",
+    hint: "api.getdesign.app",
+    docsPath: "/surfaces/api",
+  },
+  {
+    id: "cli",
+    label: "cli",
+    hint: "npx @getdesign/cli",
+    docsPath: "/surfaces/cli",
+  },
+  {
+    id: "sdk",
+    label: "sdk",
+    hint: "@getdesign/sdk",
+    docsPath: "/surfaces/sdk",
+  },
+  {
+    id: "skill",
+    label: "skill",
+    hint: "skills.sh",
+    docsPath: "/surfaces/skill",
+  },
+];
+
+export const CHROME_LABEL_TEMPLATES: Record<SurfaceId, string> = {
+  web: "getdesign.app",
+  api: "api.getdesign.app/?url={url}",
+  cli: "~ · zsh",
+  sdk: "app.ts · @getdesign/sdk",
+  skill: "claude-code · skill: getdesign",
+};
+
+export function docsUrl(path = ""): string {
+  if (!path) return DOCS_BASE_URL;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${DOCS_BASE_URL}${normalized}`;
+}
+
+export function chromeLabel(surface: SurfaceId, siteUrl: string): string {
+  const template = CHROME_LABEL_TEMPLATES[surface];
+  return template.replace("{url}", siteUrl);
+}
+
+export function getDemoSite(id: string): DemoSite {
+  const site = DEMO_SITES.find((entry) => entry.id === id);
+  if (!site) {
+    const fallback = DEMO_SITES[0];
+    if (!fallback) {
+      throw new Error("DEMO_SITES is empty");
+    }
+    return fallback;
+  }
+  return site;
+}
+
+/** Absolute HTTPS URL used in copyable examples. */
+export function exampleUrl(siteUrl: string): string {
+  return siteUrl.startsWith("http") ? siteUrl : `https://${siteUrl}`;
+}
+
+export function buildApiRequest(siteUrl: string): string {
+  const url = exampleUrl(siteUrl);
+  return `GET ${API_BASE_URL}/?url=${url}\nAccept: text/markdown`;
+}
+
+export function buildCurlExample(siteUrl: string): string {
+  const url = exampleUrl(siteUrl);
+  const host = siteUrl.replace(/^https?:\/\//, "").split("/")[0] ?? "site";
+  const slug = host.replace(/\./g, "-");
+  return `curl "${API_BASE_URL}/?url=${url}" \\\n  -H "Accept: text/markdown" \\\n  -o ${slug}.design.md`;
+}
+
+export function buildCliCommand(siteUrl: string): string {
+  return `bunx @getdesign/cli ${exampleUrl(siteUrl)}`;
+}
+
+export function buildSdkInstall(): string {
+  return "bun add @getdesign/sdk";
+}
+
+export function buildSdkGetDesignSnippet(siteUrl: string): string {
+  const url = exampleUrl(siteUrl);
+  return `import { getDesign } from "@getdesign/sdk";
+
+const system = await getDesign("${url}", {
+  credentials: {
+    daytonaApiKey: process.env.DAYTONA_API_KEY,
+    openaiApiKey: process.env.OPENAI_API_KEY,
+  },
+});
+console.log(system.markdown);`;
+}
+
+export function buildSdkStreamSnippet(siteUrl: string): string {
+  const url = exampleUrl(siteUrl);
+  return `import { streamDesign } from "@getdesign/sdk";
+
+for await (const event of streamDesign("${url}", {
+  credentials: {
+    daytonaApiKey: process.env.DAYTONA_API_KEY,
+    openaiApiKey: process.env.OPENAI_API_KEY,
+  },
+})) {
+  if (event.type === "progress") console.log(event.event);
+  if (event.type === "result") console.log(event.result.markdown);
+}`;
+}
+
+/** Compact stream snippet for animated demos (matches marketing surface). */
+export function buildSdkDemoSnippet(siteUrl: string): string {
+  return `import { streamDesign } from "@getdesign/sdk";
+
+const stream = streamDesign("${siteUrl}");
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}`;
+}

--- a/packages/content/tsconfig.json
+++ b/packages/content/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@getdesign/config/tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/content/tsconfig.json
+++ b/packages/content/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "@getdesign/config/tsconfig.base.json",
   "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["bun"]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds dashboard pages for **API**, **CLI**, **SDK**, **Skills**, **Docs**, and **Support** so sidebar links no longer 404
- Each API/CLI/SDK page includes a marketing-style animated surface demo plus copy-paste quickstarts and docs links
- Introduces `@getdesign/content` for shared demo sites, surface metadata, and snippet builders (consumed by dashboard, web, and video)
- Documents the current auth model clearly: **no getdesign API key in v1**; BYOK Daytona/OpenAI for full CLI/SDK/API capture runs
- Points the Agent “setup needed” CTA at `/api` BYOK docs instead of implying Settings stores an AI key

## Test plan

- [ ] Open `/api`, `/cli`, `/sdk` — demos animate; site picker + Replay work
- [ ] Copy buttons work for curl / bunx / SDK snippets
- [ ] Open `/skills`, `/docs`, `/support` — no 404; external docs links resolve
- [ ] Confirm credential callouts state there is no getdesign API key yet
- [ ] `bun test --cwd packages/content` passes
- [ ] `bun run typecheck` in `apps/web` and `apps/video` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9989f70-6c7e-43c9-b0c2-47ae7765960d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9989f70-6c7e-43c9-b0c2-47ae7765960d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

