### PR TITLE
test(agent): add brand-smoke harness and palette grounding check

### DIFF
--- a/.github/workflows/brand-smoke.yml
+++ b/.github/workflows/brand-smoke.yml
@@ -1,0 +1,58 @@
+name: Brand smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Live brand limit (used only if secrets are present)
+        required: false
+        default: "1"
+      text_only:
+        description: Live run uses text-only fallback
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  grounding:
+    name: Palette grounding unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run grounding unit tests
+        run: bun test scripts/brand-smoke.test.ts
+
+      - name: Optional live brand smoke
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          SMOKE_LIMIT: ${{ inputs.limit }}
+          SMOKE_TEXT_ONLY: ${{ inputs.text_only }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "Skipping live smoke: OPENAI_API_KEY is not set."
+            exit 0
+          fi
+          if [ "$SMOKE_TEXT_ONLY" != "true" ] && [ -z "$DAYTONA_API_KEY" ]; then
+            echo "Skipping live smoke: DAYTONA_API_KEY is not set and text_only is false."
+            exit 0
+          fi
+          ARGS=(--limit "$SMOKE_LIMIT")
+          if [ "$SMOKE_TEXT_ONLY" = "true" ]; then
+            ARGS+=(--text-only)
+          fi
+          echo "Live step is optional and skipped unless repo secrets are present."
+          bun ./scripts/brand-smoke.ts "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 - **[skill]** `skills/README.md` — overview, install commands, and link to the [skills.sh](https://skills.sh) leaderboard.
 - **[web]** Landing page now advertises five surfaces: hero dots `Web · API · CLI · SDK · Skill`, the Surfaces section grid expanded from 4 to 5 cards, and the interactive demo gained a `skill` tab showing `npx skills add`, agent trace (`WebFetch`, `browser.screenshot`, `Write`), and the resulting `design.md`.
 - **[repo]** `LICENSE` (MIT), `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and a GitHub issue + PR template set under `.github/`.
+- **[agent]** Local M11 brand-smoke harness (`bun run smoke:brands`) for 20 marketing sites: palette hex values must appear in crawled CSS, with wall-clock timings. CI (`workflow_dispatch` only) runs the grounding unit tests; live Daytona/OpenAI is skipped unless secrets are present.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf node_modules",
     "smoke:npm": "node scripts/npm-package-smoke.mjs",
+    "smoke:brands": "bun ./scripts/brand-smoke.ts",
     "postinstall": "bun run --cwd ./packages/types build && bun run --cwd ./packages/content build"
   },
   "packageManager": "bun@1.3.10",

--- a/scripts/brand-smoke.test.ts
+++ b/scripts/brand-smoke.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BRANDS,
+  formatResultTable,
+  medianMs,
+  parseBrandSmokeArgs,
+  type BrandResult,
+} from "./brand-smoke/cli.ts";
+import {
+  canonicalColorKey,
+  checkPaletteGrounding,
+  collectCssColorKeys,
+  joinStylesheetCss,
+} from "./brand-smoke/grounding.ts";
+
+const FIXTURE_CSS = `
+  :root {
+    --bg: #fff;
+    --ink: #0a0a0a;
+    --accent: #5E6AD2;
+  }
+  .hero {
+    color: rgb(10, 10, 10);
+    background: #FFFFFF;
+  }
+  .chip {
+    background: rgb(255, 255, 255);
+    border-color: rgb(94 106 210);
+  }
+`;
+
+const FIXTURE_PALETTE = {
+  groups: [
+    {
+      heading: "Primary",
+      entries: [
+        { hex: "#FFFFFF" },
+        { hex: "#0A0A0A" },
+        { hex: "#5e6ad2" },
+      ],
+    },
+  ],
+};
+
+describe("canonicalColorKey", () => {
+  test("treats #fff, #ffffff, and rgb(255,255,255) as the same color", () => {
+    expect(canonicalColorKey("#fff")).toBe("ffffff");
+    expect(canonicalColorKey("#ffffff")).toBe("ffffff");
+    expect(canonicalColorKey("#FFFFFF")).toBe("ffffff");
+    expect(canonicalColorKey("rgb(255, 255, 255)")).toBe("ffffff");
+    expect(canonicalColorKey("rgb(255,255,255)")).toBe("ffffff");
+  });
+});
+
+describe("checkPaletteGrounding", () => {
+  test("passes when every palette hex is present in fixture CSS", () => {
+    const result = checkPaletteGrounding(FIXTURE_CSS, FIXTURE_PALETTE);
+    expect(result.pass).toBe(true);
+    expect(result.misses).toEqual([]);
+  });
+
+  test("short hex in CSS grounds a long palette hex", () => {
+    const result = checkPaletteGrounding(".x { color: #fff }", {
+      groups: [{ entries: [{ hex: "#ffffff" }] }],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("long hex in CSS grounds a short palette hex", () => {
+    const result = checkPaletteGrounding(".x { color: #ffffff }", {
+      groups: [{ entries: [{ hex: "#fff" }] }],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("rgb() in CSS grounds an equivalent palette hex", () => {
+    const result = checkPaletteGrounding(
+      ".x { color: rgb(255, 255, 255); accent: rgb(94, 106, 210) }",
+      {
+        groups: [{ entries: [{ hex: "#fff" }, { hex: "#5E6AD2" }] }],
+      },
+    );
+    expect(result.pass).toBe(true);
+  });
+
+  test("space-separated rgb() matches hex", () => {
+    const result = checkPaletteGrounding(".x { color: rgb(10 10 10) }", {
+      groups: [{ entries: [{ hex: "#0a0a0a" }] }],
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test("fails with the original palette hex when CSS has no match", () => {
+    const result = checkPaletteGrounding(".x { color: #111111 }", {
+      groups: [{ entries: [{ hex: "#ff0000" }] }],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.misses).toEqual(["#ff0000"]);
+  });
+
+  test("reports only the missing entries from a mixed palette", () => {
+    const result = checkPaletteGrounding(FIXTURE_CSS, {
+      groups: [
+        {
+          entries: [
+            { hex: "#fff" },
+            { hex: "#c0ffee" },
+            { hex: "#0a0a0a" },
+          ],
+        },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.misses).toEqual(["#c0ffee"]);
+  });
+
+  test("empty palette passes", () => {
+    expect(checkPaletteGrounding(FIXTURE_CSS, { groups: [] })).toEqual({
+      pass: true,
+      misses: [],
+    });
+  });
+
+  test("joins crawled stylesheet contents before checking", () => {
+    const css = joinStylesheetCss([
+      { content: ".a { color: #abc; }" },
+      { content: ".b { background: rgb(170, 187, 204); }" },
+    ]);
+    const keys = collectCssColorKeys(css);
+    expect(keys.has("aabbcc")).toBe(true);
+    expect(
+      checkPaletteGrounding(css, {
+        groups: [{ entries: [{ hex: "#AABBCC" }] }],
+      }).pass,
+    ).toBe(true);
+  });
+});
+
+describe("brand-smoke CLI helpers", () => {
+  test("brand list is 20 unique https marketing URLs", () => {
+    expect(BRANDS).toHaveLength(20);
+    const urls = BRANDS.map((brand) => brand.url);
+    expect(new Set(urls).size).toBe(20);
+    for (const brand of BRANDS) {
+      expect(brand.url.startsWith("https://")).toBe(true);
+    }
+  });
+
+  test("parseBrandSmokeArgs reads --limit --text-only --out", () => {
+    expect(
+      parseBrandSmokeArgs(["--limit", "2", "--text-only", "--out", "/tmp/smoke"]),
+    ).toEqual({
+      limit: 2,
+      textOnly: true,
+      out: "/tmp/smoke",
+      help: false,
+    });
+  });
+
+  test("medianMs is P50 and does not treat the 90s budget as a failure", () => {
+    expect(medianMs([10_000, 95_000, 20_000])).toBe(20_000);
+    expect(medianMs([10_000, 20_000, 90_001, 100_000])).toBe(55_001);
+    expect(medianMs([])).toBeNull();
+  });
+
+  test("formatResultTable prints brand status duration grounding mode", () => {
+    const rows: BrandResult[] = [
+      {
+        brand: "cursor",
+        url: "https://cursor.com",
+        status: "ok",
+        durationMs: 42_100,
+        mode: "text_only",
+        tileCount: 0,
+        groundingPass: true,
+        groundingMisses: [],
+      },
+      {
+        brand: "linear",
+        url: "https://linear.app",
+        status: "fail",
+        error: "palette hex missing from crawled CSS: #c0ffee",
+        durationMs: 12_000,
+        mode: "visual",
+        tileCount: 3,
+        groundingPass: false,
+        groundingMisses: ["#c0ffee"],
+      },
+    ];
+
+    const table = formatResultTable(rows);
+    expect(table).toContain("brand");
+    expect(table).toContain("cursor");
+    expect(table).toContain("ok");
+    expect(table).toContain("42.1s");
+    expect(table).toContain("pass");
+    expect(table).toContain("fail(1)");
+    expect(table).toContain("text_only");
+  });
+});

--- a/scripts/brand-smoke.ts
+++ b/scripts/brand-smoke.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env bun
+/**
+ * M11 brand smoke (local / manual). Does not run on push/PR.
+ *
+ *   bun ./scripts/brand-smoke.ts [--limit N] [--text-only] [--out dir]
+ *
+ * Default requires visual capture (DAYTONA_API_KEY + OPENAI_API_KEY).
+ * `--text-only` uses visualRequirement `text_only_fallback` (OPENAI_API_KEY).
+ * Outputs go to getdesign-runs/brand-smoke/<timestamp>/ and must not be committed.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runDesign, RunDesignError } from "../packages/agent/src/runDesign.ts";
+
+import {
+  BRANDS,
+  formatDuration,
+  formatResultTable,
+  medianMs,
+  parseBrandSmokeArgs,
+  type BrandResult,
+  type BrandSmokeArgs,
+} from "./brand-smoke/cli.ts";
+import {
+  checkPaletteGrounding,
+  joinStylesheetCss,
+} from "./brand-smoke/grounding.ts";
+
+const P50_BUDGET_MS = 90_000;
+
+function loadEnvLocal(): void {
+  const candidates = [
+    resolve(import.meta.dir, "../.env.local"),
+    resolve(process.cwd(), ".env.local"),
+  ];
+
+  for (const path of candidates) {
+    let text: string;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch {
+      continue;
+    }
+
+    for (const line of text.split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (!m) continue;
+      let val = m[2]!;
+      if (
+        (val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))
+      ) {
+        val = val.slice(1, -1);
+      }
+      if (!process.env[m[1]!]) process.env[m[1]!] = val;
+    }
+  }
+}
+
+function usage(): string {
+  return `Usage: bun ./scripts/brand-smoke.ts [--limit N] [--text-only] [--out dir]
+
+Default requires visual capture (DAYTONA_API_KEY + OPENAI_API_KEY).
+--text-only uses text_only_fallback (still needs OPENAI_API_KEY).
+--out defaults to getdesign-runs/brand-smoke/<timestamp>/
+`;
+}
+
+function timestampStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+async function smokeBrand(
+  brand: (typeof BRANDS)[number],
+  textOnly: boolean,
+  brandDir: string,
+): Promise<BrandResult> {
+  const start = Date.now();
+  try {
+    const result = await runDesign(brand.url, {
+      visualRequirement: textOnly ? "text_only_fallback" : "require",
+      onPhase: (event) => {
+        const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+        if (event.phase === "crawl" && event.status === "ok") {
+          process.stderr.write(
+            `[${elapsed}s] ${brand.name}: crawl ${event.crawl.stylesheets.length} sheets\n`,
+          );
+          return;
+        }
+        if (event.phase === "synthesize" && event.status === "ok") {
+          process.stderr.write(
+            `[${elapsed}s] ${brand.name}: ${event.doc.palette.groups.length} palette groups\n`,
+          );
+        }
+      },
+    });
+
+    const grounding = checkPaletteGrounding(
+      joinStylesheetCss(result.crawl.stylesheets),
+      result.doc.palette,
+    );
+
+    await mkdir(brandDir, { recursive: true });
+    await writeFile(resolve(brandDir, "design.md"), result.markdown, "utf8");
+
+    const row: BrandResult = {
+      brand: brand.name,
+      url: brand.url,
+      status: grounding.pass ? "ok" : "fail",
+      durationMs: Date.now() - start,
+      mode: result.mode,
+      tileCount: result.tiles,
+      groundingPass: grounding.pass,
+      groundingMisses: grounding.misses,
+      ...(grounding.pass
+        ? {}
+        : {
+            error: `palette hex missing from crawled CSS: ${grounding.misses.join(", ")}`,
+          }),
+    };
+
+    await writeFile(
+      resolve(brandDir, "result.json"),
+      `${JSON.stringify(row, null, 2)}\n`,
+      "utf8",
+    );
+    return row;
+  } catch (error) {
+    const message =
+      error instanceof RunDesignError
+        ? error.message
+        : error instanceof Error
+          ? error.message
+          : String(error);
+
+    const row: BrandResult = {
+      brand: brand.name,
+      url: brand.url,
+      status: "fail",
+      error: message,
+      durationMs: Date.now() - start,
+      mode: null,
+      tileCount: 0,
+      groundingPass: false,
+      groundingMisses: [],
+    };
+
+    await mkdir(brandDir, { recursive: true });
+    await writeFile(
+      resolve(brandDir, "result.json"),
+      `${JSON.stringify(row, null, 2)}\n`,
+      "utf8",
+    );
+    return row;
+  }
+}
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+
+  let args: BrandSmokeArgs;
+  try {
+    args = parseBrandSmokeArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.stderr.write(usage());
+    process.exit(1);
+  }
+
+  if (args.help) {
+    process.stderr.write(usage());
+    process.exit(0);
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    process.stderr.write(
+      "[brand-smoke] OPENAI_API_KEY is required (even with --text-only).\n",
+    );
+    process.exit(1);
+  }
+
+  if (!args.textOnly && !process.env.DAYTONA_API_KEY) {
+    process.stderr.write(
+      "[brand-smoke] DAYTONA_API_KEY is required unless you pass --text-only.\n",
+    );
+    process.exit(1);
+  }
+
+  const selected = BRANDS.slice(0, Math.min(args.limit, BRANDS.length));
+  const outDir = resolve(
+    process.cwd(),
+    args.out ?? `getdesign-runs/brand-smoke/${timestampStamp()}`,
+  );
+  await mkdir(outDir, { recursive: true });
+
+  process.stderr.write(
+    `[brand-smoke] ${selected.length} brand${selected.length === 1 ? "" : "s"} → ${outDir}${
+      args.textOnly ? " (text-only)" : ""
+    }\n`,
+  );
+
+  const results: BrandResult[] = [];
+  for (const [index, brand] of selected.entries()) {
+    process.stderr.write(
+      `[brand-smoke] ${index + 1}/${selected.length} ${brand.name} ${brand.url}\n`,
+    );
+    const row = await smokeBrand(brand, args.textOnly, resolve(outDir, brand.name));
+    results.push(row);
+    process.stderr.write(
+      `[brand-smoke] ${brand.name} ${row.status} ${formatDuration(row.durationMs)} grounding=${
+        row.groundingPass ? "pass" : "fail"
+      } mode=${row.mode ?? "-"}\n`,
+    );
+  }
+
+  const p50Ms = medianMs(results.map((row) => row.durationMs));
+  const failed = results.filter((row) => row.status === "fail").length;
+  const summary = {
+    startedAt: new Date().toISOString(),
+    outDir,
+    textOnly: args.textOnly,
+    limit: selected.length,
+    p50Ms,
+    p50Warning: p50Ms !== null && p50Ms > P50_BUDGET_MS,
+    passed: results.length - failed,
+    failed,
+    results,
+  };
+
+  await writeFile(
+    resolve(outDir, "summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+    "utf8",
+  );
+
+  process.stderr.write(`\n${formatResultTable(results)}\n`);
+  if (p50Ms !== null) {
+    process.stderr.write(`[brand-smoke] P50 ${formatDuration(p50Ms)} (${p50Ms}ms)\n`);
+    if (p50Ms > P50_BUDGET_MS) {
+      process.stderr.write(
+        `[brand-smoke] warning: P50 ${p50Ms}ms exceeds ${P50_BUDGET_MS}ms (G5 is aspirational; not failing)\n`,
+      );
+    }
+  }
+  process.stderr.write(`[brand-smoke] wrote ${resolve(outDir, "summary.json")}\n`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("[brand-smoke] failed:", error);
+    process.exit(1);
+  });
+}

--- a/scripts/brand-smoke/cli.ts
+++ b/scripts/brand-smoke/cli.ts
@@ -1,0 +1,130 @@
+export const BRANDS = [
+  { name: "cursor", url: "https://cursor.com" },
+  { name: "linear", url: "https://linear.app" },
+  { name: "vercel", url: "https://vercel.com" },
+  { name: "stripe", url: "https://stripe.com" },
+  { name: "notion", url: "https://notion.so" },
+  { name: "figma", url: "https://figma.com" },
+  { name: "raycast", url: "https://raycast.com" },
+  { name: "github", url: "https://github.com" },
+  { name: "openai", url: "https://openai.com" },
+  { name: "anthropic", url: "https://anthropic.com" },
+  { name: "resend", url: "https://resend.com" },
+  { name: "clerk", url: "https://clerk.com" },
+  { name: "workos", url: "https://workos.com" },
+  { name: "convex", url: "https://convex.dev" },
+  { name: "supabase", url: "https://supabase.com" },
+  { name: "tailwindcss", url: "https://tailwindcss.com" },
+  { name: "framer", url: "https://framer.com" },
+  { name: "apple", url: "https://apple.com" },
+  { name: "bun", url: "https://bun.sh" },
+  { name: "expo", url: "https://expo.dev" },
+] as const;
+
+export type BrandSmokeArgs = {
+  limit: number;
+  textOnly: boolean;
+  out?: string;
+  help: boolean;
+};
+
+export type BrandResult = {
+  brand: string;
+  url: string;
+  status: "ok" | "fail";
+  error?: string;
+  durationMs: number;
+  mode: "visual" | "text_only" | null;
+  tileCount: number;
+  groundingPass: boolean;
+  groundingMisses: string[];
+};
+
+export function parseBrandSmokeArgs(argv: string[]): BrandSmokeArgs {
+  const parsed: BrandSmokeArgs = {
+    limit: BRANDS.length,
+    textOnly: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token) continue;
+
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+
+    if (token === "--text-only") {
+      parsed.textOnly = true;
+      continue;
+    }
+
+    if (token === "--limit") {
+      const raw = argv[i + 1];
+      if (!raw || raw.startsWith("-")) {
+        throw new Error("--limit requires a positive integer.");
+      }
+      const n = Number.parseInt(raw, 10);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`--limit must be a positive integer, got ${raw}`);
+      }
+      parsed.limit = n;
+      i += 1;
+      continue;
+    }
+
+    if (token === "--out") {
+      const raw = argv[i + 1];
+      if (!raw || raw.startsWith("-")) {
+        throw new Error("--out requires a directory path.");
+      }
+      parsed.out = raw;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return parsed;
+}
+
+export function medianMs(durations: readonly number[]): number | null {
+  if (durations.length === 0) return null;
+  const sorted = [...durations].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid]!;
+  }
+  return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+}
+
+export function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function formatResultTable(results: readonly BrandResult[]): string {
+  const headers = ["brand", "status", "duration", "grounding", "mode"] as const;
+  const rows = results.map((row) => [
+    row.brand,
+    row.status,
+    formatDuration(row.durationMs),
+    row.groundingPass
+      ? "pass"
+      : row.error && row.groundingMisses.length === 0
+        ? "n/a"
+        : `fail${row.groundingMisses.length > 0 ? `(${row.groundingMisses.length})` : ""}`,
+    row.mode ?? "-",
+  ]);
+
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]!.length)),
+  );
+
+  const line = (cells: readonly string[]) =>
+    cells.map((cell, index) => cell.padEnd(widths[index]!)).join("  ");
+
+  return [line([...headers]), ...rows.map((row) => line(row))].join("\n");
+}

--- a/scripts/brand-smoke/grounding.ts
+++ b/scripts/brand-smoke/grounding.ts
@@ -1,0 +1,144 @@
+/**
+ * M3/G2 palette grounding: every DesignDoc palette hex must appear in
+ * crawled CSS. #RGB, #RRGGBB, and rgb() are compared as the same color
+ * (#fff === #ffffff === rgb(255,255,255)).
+ */
+
+export type PaletteLike = {
+  groups: Array<{
+    heading?: string;
+    entries: Array<{ hex: string }>;
+  }>;
+};
+
+export type GroundingResult = {
+  pass: boolean;
+  misses: string[];
+};
+
+/** Lowercase 6-digit RGB without `#`, or null if the value is not a hex/rgb color. */
+export function canonicalColorKey(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("#")) {
+    return hexToKey(trimmed);
+  }
+
+  const rgb = trimmed.match(/^rgba?\(\s*([^)]+)\)$/i);
+  if (rgb?.[1]) {
+    return rgbArgsToKey(rgb[1]);
+  }
+
+  return hexToKey(trimmed.startsWith("#") ? trimmed : `#${trimmed}`);
+}
+
+export function collectCssColorKeys(css: string): Set<string> {
+  const keys = new Set<string>();
+  const hexInCss =
+    /#(?:[\dA-Fa-f]{3}|[\dA-Fa-f]{4}|[\dA-Fa-f]{6}|[\dA-Fa-f]{8})\b/g;
+  const rgbInCss = /rgba?\(\s*([^)]+)\)/gi;
+
+  for (const match of css.matchAll(hexInCss)) {
+    const key = hexToKey(match[0]);
+    if (key) keys.add(key);
+  }
+
+  for (const match of css.matchAll(rgbInCss)) {
+    const inner = match[1];
+    if (!inner) continue;
+    const key = rgbArgsToKey(inner);
+    if (key) keys.add(key);
+  }
+
+  return keys;
+}
+
+export function joinStylesheetCss(
+  stylesheets: ReadonlyArray<{ content: string }>,
+): string {
+  return stylesheets.map((sheet) => sheet.content).join("\n");
+}
+
+export function checkPaletteGrounding(
+  css: string,
+  palette: PaletteLike,
+): GroundingResult {
+  const cssKeys = collectCssColorKeys(css);
+  const misses: string[] = [];
+  const seen = new Set<string>();
+
+  for (const group of palette.groups) {
+    for (const entry of group.entries) {
+      if (seen.has(entry.hex)) continue;
+      seen.add(entry.hex);
+
+      const key = canonicalColorKey(entry.hex);
+      if (!key || !cssKeys.has(key)) {
+        misses.push(entry.hex);
+      }
+    }
+  }
+
+  return { pass: misses.length === 0, misses };
+}
+
+function hexToKey(hex: string): string | null {
+  const raw = hex.trim().replace(/^#/, "").toLowerCase();
+
+  if (/^[\da-f]{3}$/.test(raw)) {
+    return raw
+      .split("")
+      .map((ch) => `${ch}${ch}`)
+      .join("");
+  }
+
+  if (/^[\da-f]{4}$/.test(raw)) {
+    return raw
+      .slice(0, 3)
+      .split("")
+      .map((ch) => `${ch}${ch}`)
+      .join("");
+  }
+
+  if (/^[\da-f]{6}$/.test(raw)) {
+    return raw;
+  }
+
+  if (/^[\da-f]{8}$/.test(raw)) {
+    return raw.slice(0, 6);
+  }
+
+  return null;
+}
+
+function rgbArgsToKey(inner: string): string | null {
+  const withoutAlpha = inner.replace(/\/\s*[\d.]+%?\s*$/, "").trim();
+  const parts = withoutAlpha.includes(",")
+    ? withoutAlpha.split(",")
+    : withoutAlpha.split(/\s+/);
+
+  if (parts.length < 3) return null;
+
+  const r = cssChannel(parts[0]!);
+  const g = cssChannel(parts[1]!);
+  const b = cssChannel(parts[2]!);
+  if (r === null || g === null || b === null) return null;
+
+  return [r, g, b]
+    .map((n) => n.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function cssChannel(token: string): number | null {
+  const value = token.trim();
+  if (value.endsWith("%")) {
+    const pct = Number.parseFloat(value.slice(0, -1));
+    if (!Number.isFinite(pct)) return null;
+    const n = Math.round((pct / 100) * 255);
+    return n < 0 || n > 255 ? null : n;
+  }
+
+  const n = Number.parseFloat(value);
+  if (!Number.isFinite(n)) return null;
+  const rounded = Math.round(n);
+  return rounded < 0 || rounded > 255 ? null : rounded;
+}


### PR DESCRIPTION
## Summary
- Adds a local/manual 20-brand smoke harness (`bun run smoke:brands`) that times runs and fails a brand if any palette hex is missing from crawled CSS.
- Grounding helper is unit-tested with fixture CSS only. No network in CI unit tests.
- GitHub Action is `workflow_dispatch` only. The live Daytona/OpenAI step skips when secrets are absent.

## Surface(s) affected
- [x] Repo tooling / docs

## Breaking changes?
- [x] No

## Test plan
- [ ] `bun test scripts/brand-smoke.test.ts` (14 tests)
- [ ] `bun ./scripts/brand-smoke.ts --limit 2 --text-only` with `OPENAI_API_KEY` set
- [ ] Confirm workflow does not run on push/PR


Made with [Cursor](https://cursor.com)