### PR TITLE
fix(dashboard): require explicit text-only after capture failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 
 ### Changed
 
+- **[dashboard]** Capture failures now stop the run. Text-only is an explicit "Continue with text-only" choice, not a silent fallback.
 - **[web]** Surfaces section heading `"Four surfaces, one agent."` → `"Five surfaces, one agent."` with revised subhead.
 - **[web]** Footer GitHub link now points at [github.com/MohtashamMurshid/getdesign](https://github.com/MohtashamMurshid/getdesign) instead of the `github.com` placeholder.
 

--- a/apps/dashboard/app/(dashboard)/runs/[slug]/run-progress.tsx
+++ b/apps/dashboard/app/(dashboard)/runs/[slug]/run-progress.tsx
@@ -5,7 +5,13 @@ import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "motion/react";
 import { useQuery } from "convex/react";
 
-import { toRunState, type RunState, type RunStep } from "@/lib/runs-store";
+import { isCaptureFailure } from "@/lib/is-capture-failure";
+import {
+  runErrorMessage,
+  toRunState,
+  type RunState,
+  type RunStep,
+} from "@/lib/runs-store";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 
@@ -32,6 +38,13 @@ const STEP_ORDER: RunStep[] = [
 const STEP_DAG: Array<RunStep | RunStep[]> = [
   "crawl",
   ["capture", "extract"],
+  "describe",
+  "synthesize",
+  "render",
+];
+
+const TEXT_ONLY_DAG: Array<RunStep | RunStep[]> = [
+  "extract",
   "describe",
   "synthesize",
   "render",
@@ -68,10 +81,11 @@ export function RunProgress({
     userId,
   });
   const run = liveRun ? toRunState(liveRun) : initialRun;
-  const runError =
-    typeof run.error === "object" && run.error ? run.error.message : run.error;
-  const [error, setError] = useState<string | null>(runError ?? null);
-  const [isRunning, setIsRunning] = useState(false);
+  const runError = runErrorMessage(run.error);
+  const [error, setError] = useState<string | null>(runError);
+  const [pendingAction, setPendingAction] = useState<"retry" | "text-only" | null>(
+    null,
+  );
   const startedRef = useRef(false);
 
   const artifacts = useRunArtifacts(run, userId);
@@ -86,12 +100,9 @@ export function RunProgress({
   );
   const progress = Math.round((completedCount / STEP_ORDER.length) * 100);
 
-  const runSteps = useCallback(async () => {
-    setIsRunning(true);
-    setError(null);
-
-    try {
-      for (const group of STEP_DAG) {
+  const runPipeline = useCallback(
+    async (dag: Array<RunStep | RunStep[]>) => {
+      for (const group of dag) {
         if (Array.isArray(group)) {
           await Promise.all(group.map((step) => postStep(run.id, step)));
         } else {
@@ -99,12 +110,44 @@ export function RunProgress({
         }
       }
       router.refresh();
+    },
+    [router, run.id],
+  );
+
+  const runSteps = useCallback(async () => {
+    setPendingAction("retry");
+    setError(null);
+
+    try {
+      await runPipeline(STEP_DAG);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Run failed.");
     } finally {
-      setIsRunning(false);
+      setPendingAction(null);
     }
-  }, [router, run.id]);
+  }, [runPipeline]);
+
+  const continueTextOnly = useCallback(async () => {
+    setPendingAction("text-only");
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/runs/${run.id}/continue-text-only`, {
+        method: "POST",
+      });
+      const payload = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(payload.error ?? "Could not continue as text-only.");
+      }
+      await runPipeline(TEXT_ONLY_DAG);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Run failed.");
+    } finally {
+      setPendingAction(null);
+    }
+  }, [run.id, runPipeline]);
 
   useEffect(() => {
     if (startedRef.current) return;
@@ -126,7 +169,13 @@ export function RunProgress({
   }, [runError]);
 
   const onRetry = useCallback(() => void runSteps(), [runSteps]);
+  const onContinueTextOnly = useCallback(
+    () => void continueTextOnly(),
+    [continueTextOnly],
+  );
   const onOpen = useCallback(() => router.refresh(), [router]);
+  const showTextOnly =
+    isCaptureFailure(run.error) || isCaptureFailure(error);
 
   const siteCaption = run.siteName ?? safeHostname(run.url);
 
@@ -185,7 +234,10 @@ export function RunProgress({
                 <FailedStage
                   error={error ?? runError ?? "Run failed."}
                   onRetry={onRetry}
-                  isRetrying={isRunning}
+                  onContinueTextOnly={onContinueTextOnly}
+                  isRetrying={pendingAction === "retry"}
+                  isContinuing={pendingAction === "text-only"}
+                  showTextOnly={showTextOnly}
                 />
               ) : null}
             </motion.div>

--- a/apps/dashboard/app/(dashboard)/runs/[slug]/stages/failed-stage.tsx
+++ b/apps/dashboard/app/(dashboard)/runs/[slug]/stages/failed-stage.tsx
@@ -5,12 +5,19 @@ import { Button } from "@/components/ui/button";
 export function FailedStage({
   error,
   onRetry,
+  onContinueTextOnly,
   isRetrying,
+  isContinuing,
+  showTextOnly,
 }: {
   error: string;
   onRetry: () => void;
+  onContinueTextOnly?: () => void;
   isRetrying: boolean;
+  isContinuing: boolean;
+  showTextOnly: boolean;
 }) {
+  const isBusy = isRetrying || isContinuing;
   return (
     <div className="flex h-full w-full items-center justify-center bg-destructive/5 p-6">
       <div className="flex w-full max-w-md flex-col items-center gap-3 text-center">
@@ -33,9 +40,31 @@ export function FailedStage({
         </div>
         <p className="text-sm font-medium">Run failed</p>
         <p className="text-xs text-muted-foreground">{error}</p>
-        <Button size="sm" variant="destructive" onClick={onRetry} disabled={isRetrying}>
-          {isRetrying ? "Retrying…" : "Retry"}
-        </Button>
+        {showTextOnly ? (
+          <p className="text-xs text-muted-foreground">
+            Visual capture failed. Continue without screenshots, or retry.
+          </p>
+        ) : null}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={onRetry}
+            disabled={isBusy}
+          >
+            {isRetrying ? "Retrying…" : "Retry"}
+          </Button>
+          {showTextOnly && onContinueTextOnly ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onContinueTextOnly}
+              disabled={isBusy}
+            >
+              {isContinuing ? "Continuing…" : "Continue with text-only"}
+            </Button>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/apps/dashboard/app/api/runs/[id]/_run-step.ts
+++ b/apps/dashboard/app/api/runs/[id]/_run-step.ts
@@ -93,7 +93,7 @@ export function runStepHandler(step: RunStep) {
         userId: user.id,
         step: inferFailedStep(error, step),
         message: error instanceof Error ? error.message : "Run failed.",
-        code: error instanceof Error ? error.name : undefined,
+        code: inferErrorCode(error),
       });
       return NextResponse.json(
         { error: error instanceof Error ? error.message : "Run failed." },
@@ -152,27 +152,41 @@ async function runCaptureStep({
     throw new StepError(
       "capture",
       "No Daytona API key available; set DAYTONA_API_KEY before starting a visual run.",
+      "capture_failed",
     );
   }
 
   await beginStep(convex, runId, userId, "capture", "Capturing page");
-  const captured = await runVisual(
-    { url: crawl.sourceUrl },
-    { daytonaApiKey: process.env.DAYTONA_API_KEY },
-  );
+  let captured: VisualResult;
+  try {
+    captured = await runVisual(
+      { url: crawl.sourceUrl },
+      { daytonaApiKey: process.env.DAYTONA_API_KEY },
+    );
+  } catch (error) {
+    throw new StepError(
+      "capture",
+      error instanceof Error ? error.message : "Visual capture failed.",
+      "capture_failed",
+    );
+  }
+  if (captured.status !== "captured") {
+    throw new StepError(
+      "capture",
+      captured.reason ?? "Visual capture failed.",
+      "capture_failed",
+    );
+  }
   const visual = await storeVisual(convex, runId, userId, captured);
-  const mode = visual.status === "captured" ? "visual" : "text_only";
   await finishStep(
     convex,
     runId,
     userId,
     "capture",
-    visual.status === "captured" ? "ok" : "skipped",
-    visual.status === "captured"
-      ? `Captured ${visual.tiles.length} tiles`
-      : (visual.reason ?? "Capture skipped"),
+    "ok",
+    `Captured ${visual.tiles.length} tiles`,
     {
-      mode,
+      mode: "visual",
       tiles: visual.tiles.length,
     },
   );
@@ -546,13 +560,20 @@ class StepError extends Error {
   constructor(
     readonly step: RunStep,
     message: string,
+    readonly code?: string,
   ) {
     super(message);
-    this.name = "StepError";
+    this.name = code ?? "StepError";
   }
 }
 
 function inferFailedStep(error: unknown, fallback: RunStep): RunStep {
   if (error instanceof StepError) return error.step;
   return fallback;
+}
+
+function inferErrorCode(error: unknown): string | undefined {
+  if (error instanceof StepError) return error.code ?? error.name;
+  if (error instanceof Error) return error.name;
+  return undefined;
 }

--- a/apps/dashboard/app/api/runs/[id]/continue-text-only/route.ts
+++ b/apps/dashboard/app/api/runs/[id]/continue-text-only/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+
+import { getConvexClient } from "@/lib/convex-server";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { user } = await withAuth({ ensureSignedIn: true });
+  const { id } = await params;
+  const runId = id as Id<"designRuns">;
+  const convex = getConvexClient();
+
+  const run = await convex.query(api.designRuns.get, {
+    id: runId,
+    userId: user.id,
+  });
+
+  if (!run) {
+    return NextResponse.json({ error: "Run not found." }, { status: 404 });
+  }
+
+  if (run.status === "completed") {
+    return NextResponse.json(
+      { error: "Run already completed." },
+      { status: 409 },
+    );
+  }
+
+  if (run.steps.capture === "ok") {
+    return NextResponse.json(
+      { error: "Visual capture already succeeded." },
+      { status: 409 },
+    );
+  }
+
+  try {
+    await convex.mutation(api.designRuns.resumeTextOnly, {
+      id: runId,
+      userId: user.id,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Could not continue as text-only.";
+    if (/already completed|already succeeded/i.test(message)) {
+      return NextResponse.json({ error: message }, { status: 409 });
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/dashboard/lib/is-capture-failure.test.ts
+++ b/apps/dashboard/lib/is-capture-failure.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck — dashboard tsc has no bun:test types
+import { expect, test } from "bun:test";
+
+import { isCaptureFailure } from "./is-capture-failure";
+
+test("detects capture_failed code", () => {
+  expect(
+    isCaptureFailure({ code: "capture_failed", message: "something else" }),
+  ).toBe(true);
+  expect(isCaptureFailure({ name: "capture_failed" })).toBe(true);
+});
+
+test("detects capture or Daytona wording", () => {
+  expect(isCaptureFailure("Visual capture failed.")).toBe(true);
+  expect(
+    isCaptureFailure("No Daytona API key available; set DAYTONA_API_KEY."),
+  ).toBe(true);
+  expect(
+    isCaptureFailure({ message: "Capture skipped", reason: "browser never ready" }),
+  ).toBe(true);
+  expect(isCaptureFailure({ reason: "Daytona sandbox timed out" })).toBe(true);
+});
+
+test("ignores unrelated errors", () => {
+  expect(isCaptureFailure(null)).toBe(false);
+  expect(isCaptureFailure(undefined)).toBe(false);
+  expect(isCaptureFailure("Token artifact missing.")).toBe(false);
+  expect(isCaptureFailure({ code: "extract_failed", message: "bad tokens" })).toBe(
+    false,
+  );
+});

--- a/apps/dashboard/lib/is-capture-failure.ts
+++ b/apps/dashboard/lib/is-capture-failure.ts
@@ -1,0 +1,27 @@
+const CAPTURE_CODE = "capture_failed";
+const CAPTURE_HINT = /capture|daytona/i;
+
+export function isCaptureFailure(error: unknown): boolean {
+  if (error == null) return false;
+
+  if (typeof error === "string") {
+    return CAPTURE_HINT.test(error);
+  }
+
+  if (typeof error !== "object") return false;
+
+  const record = error as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+    reason?: unknown;
+  };
+
+  if (record.code === CAPTURE_CODE || record.name === CAPTURE_CODE) {
+    return true;
+  }
+
+  return [record.message, record.reason].some(
+    (value) => typeof value === "string" && CAPTURE_HINT.test(value),
+  );
+}

--- a/apps/dashboard/lib/runs-store.ts
+++ b/apps/dashboard/lib/runs-store.ts
@@ -53,9 +53,13 @@ export function toRunState(run: Omit<RunState, "id"> & { id?: string }): RunStat
   return {
     ...run,
     id: run.id ?? String(run._id),
-    error:
-      typeof run.error === "object" && run.error
-        ? run.error.message
-        : run.error,
   };
+}
+
+export function runErrorMessage(
+  error: RunState["error"] | null | undefined,
+): string | null {
+  if (!error) return null;
+  if (typeof error === "string") return error;
+  return error.message;
 }

--- a/convex/designRuns.ts
+++ b/convex/designRuns.ts
@@ -258,3 +258,48 @@ export const failStep = mutation({
     return null;
   },
 });
+
+export const resumeTextOnly = mutation({
+  args: {
+    id: v.id("designRuns"),
+    userId: v.string(),
+  },
+  returns: v.object({ ok: v.literal(true) }),
+  handler: async (ctx, args) => {
+    const run = await getOwnedRun(ctx, args.id, args.userId);
+    if (!run) throw new ConvexError("Run not found.");
+    if (run.status === "completed") {
+      throw new ConvexError({
+        code: "ALREADY_COMPLETED",
+        message: "Run already completed.",
+      });
+    }
+    if (run.steps.capture === "ok") {
+      throw new ConvexError({
+        code: "CAPTURE_ALREADY_OK",
+        message: "Visual capture already succeeded.",
+      });
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(args.id, {
+      status: "running",
+      currentStep: "extract",
+      message: "Continuing without screenshots",
+      mode: "text_only",
+      error: undefined,
+      steps: { ...run.steps, capture: "skipped" },
+      traceEvents: [
+        ...(run.traceEvents ?? []),
+        {
+          step: "capture",
+          status: "skipped",
+          message: "Continuing without screenshots",
+          at: now,
+        },
+      ],
+      updatedAt: now,
+    });
+    return { ok: true as const };
+  },
+});


### PR DESCRIPTION
## Summary
- Capture failures stop the run instead of silently skipping to text-only.
- Failed runs show Retry (try Daytona again) and Continue with text-only (skip screenshots, set `mode: text_only`, resume extract → render).
- Adds `resumeTextOnly` on Convex and `POST /api/runs/[id]/continue-text-only`.

## Surface(s) affected
- [x] Convex (`convex/`)
- [ ] Shared package (`agent` / `tools` / `types` / `ui` / `config`)

Dashboard run UI.

## Breaking changes?
- [x] No

## Merge note
This and `feat/v1-byok-credentials` both touch `_run-step.ts`. Merge BYOK first, then rebase this.

## Test plan
- [ ] `bun test apps/dashboard/lib/is-capture-failure.test.ts`
- [ ] Start a run with no Daytona key: run fails, both buttons show
- [ ] Retry attempts capture again
- [ ] Continue with text-only produces a `design.md` with the text-only banner
- [ ] Run `npx convex dev` so `resumeTextOnly` is published


Made with [Cursor](https://cursor.com)