### PR TITLE
feat(dashboard): store encrypted per-user Daytona and OpenAI keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 
 ### Added
 
+- **[dashboard]** Account stores encrypted per-user Daytona and OpenAI keys. Dashboard runs decrypt those keys on the server and no longer read `DAYTONA_API_KEY` / `OPENAI_API_KEY` from the process environment.
 - **[dashboard]** API, CLI, SDK, Skills, Docs, and Support pages with marketing-style animated demos, copy-paste quickstarts, and links to `docs.getdesign.app`. Documents that v1 has no getdesign API key; full runs use BYOK Daytona/OpenAI credentials.
 - **[content]** New `@getdesign/content` package for shared demo sites, surface metadata, docs URLs, and snippet builders (used by dashboard, web, and video).
 - **[tools]** `@getdesign/tools` now ships concrete `crawler`, `extractors`, `render`, and `daytona` modules with deterministic URL/CSS resolution, token extraction, markdown rendering, and typed Daytona helpers.

--- a/apps/dashboard/CONTEXT.md
+++ b/apps/dashboard/CONTEXT.md
@@ -7,3 +7,4 @@ Authenticated product dashboard (Next.js + WorkOS AuthKit).
 - **Surface page** — in-app docs + animated preview for API, CLI, SDK, or Skills.
 - **Developer kit** — shared UI under `components/developer/` for surface pages.
 - **Credential callout** — docs-only note that v1 has no getdesign API key; BYOK uses Daytona/OpenAI.
+- **Provider keys** — per-user Daytona and OpenAI keys saved from Account, stored as ciphertext in Convex. Dashboard runs decrypt them on the server and never fall back to `process.env`.

--- a/apps/dashboard/app/(dashboard)/account/page.tsx
+++ b/apps/dashboard/app/(dashboard)/account/page.tsx
@@ -2,6 +2,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { UserProfile } from "@workos-inc/widgets";
 import { redirect } from "next/navigation";
 
+import { api } from "@convex/_generated/api";
 import { WidgetLoadingGate } from "@/components/widget-loading-gate";
 import { WorkOsWidgetsProvider } from "@/components/workos-widgets-provider";
 import {
@@ -10,6 +11,9 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
 } from "@/components/ui/breadcrumb";
+import { getConvexClient } from "@/lib/convex-server";
+
+import { ProviderKeysCard } from "./provider-keys-card";
 
 export default async function AccountPage() {
   const { accessToken, user } = await withAuth();
@@ -17,6 +21,10 @@ export default async function AccountPage() {
   if (!user || !accessToken) {
     redirect("/sign-in");
   }
+
+  const keys = await getConvexClient().query(api.userCredentials.listForUser, {
+    userId: user.id,
+  });
 
   return (
     <>
@@ -32,6 +40,7 @@ export default async function AccountPage() {
         </div>
       </header>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <ProviderKeysCard keys={keys} />
         <WorkOsWidgetsProvider>
           <WidgetLoadingGate>
             <UserProfile authToken={accessToken} />

--- a/apps/dashboard/app/(dashboard)/account/provider-keys-card.tsx
+++ b/apps/dashboard/app/(dashboard)/account/provider-keys-card.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState, type ChangeEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export type ProviderKeyMeta = {
+  provider: "daytona" | "openai";
+  keySuffix: string;
+  updatedAt: number;
+};
+
+type ProviderId = ProviderKeyMeta["provider"];
+
+const PROVIDERS: Array<{
+  id: ProviderId;
+  label: string;
+  placeholder: string;
+}> = [
+  { id: "daytona", label: "Daytona", placeholder: "Daytona API key" },
+  { id: "openai", label: "OpenAI", placeholder: "OpenAI API key" },
+];
+
+function formatUpdatedAt(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function ProviderKeysCard({ keys }: { keys: ProviderKeyMeta[] }) {
+  return (
+    <section className="rounded-xl border bg-card p-4">
+      <h2 className="text-sm font-medium">Provider keys</h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Dashboard runs use these keys. They are encrypted at rest and never
+        shown again after you save.
+      </p>
+      <div className="mt-4 flex flex-col gap-4">
+        {PROVIDERS.map((provider) => (
+          <ProviderKeyRow
+            key={provider.id}
+            provider={provider}
+            stored={keys.find((entry) => entry.provider === provider.id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ProviderKeyRow({
+  provider,
+  stored,
+}: {
+  provider: (typeof PROVIDERS)[number];
+  stored?: ProviderKeyMeta;
+}) {
+  const router = useRouter();
+  const [draft, setDraft] = useState("");
+  const [replacing, setReplacing] = useState(false);
+  const [optimistic, setOptimistic] = useState<ProviderKeyMeta | null>();
+  const [pending, setPending] = useState<"save" | "remove" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOptimistic(undefined);
+  }, [stored?.keySuffix, stored?.updatedAt]);
+
+  const current = optimistic === undefined ? stored : optimistic ?? undefined;
+  const showForm = !current || replacing;
+
+  async function save() {
+    setError(null);
+    setPending("save");
+    try {
+      const response = await fetch("/api/credentials", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: provider.id, key: draft }),
+      });
+      const payload = (await response.json()) as {
+        error?: string;
+        keySuffix?: string;
+      };
+      if (!response.ok || !payload.keySuffix) {
+        setError(payload.error ?? "Could not save key.");
+        return;
+      }
+      setDraft("");
+      setReplacing(false);
+      setOptimistic({
+        provider: provider.id,
+        keySuffix: payload.keySuffix,
+        updatedAt: Date.now(),
+      });
+      router.refresh();
+    } catch {
+      setError("Could not save key.");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function remove() {
+    setError(null);
+    setPending("remove");
+    try {
+      const response = await fetch("/api/credentials", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: provider.id }),
+      });
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not remove key.");
+        return;
+      }
+      setDraft("");
+      setReplacing(false);
+      setOptimistic(null);
+      router.refresh();
+    } catch {
+      setError("Could not remove key.");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="text-xs text-muted-foreground">{provider.label}</p>
+      {showForm ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            value={draft}
+            placeholder={provider.placeholder}
+            disabled={pending !== null}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setDraft(event.target.value)
+            }
+            className="max-w-sm"
+          />
+          <Button
+            size="sm"
+            disabled={pending !== null || !draft.trim()}
+            onClick={() => void save()}
+          >
+            {pending === "save" ? "Saving" : "Save"}
+          </Button>
+          {current ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending !== null}
+              onClick={() => {
+                setDraft("");
+                setReplacing(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="font-mono text-xs">••••{current.keySuffix}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Updated {formatUpdatedAt(current.updatedAt)}
+            </p>
+          </div>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={pending !== null}
+              onClick={() => {
+                setDraft("");
+                setReplacing(true);
+                setError(null);
+              }}
+            >
+              Replace
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={pending !== null}
+              onClick={() => void remove()}
+            >
+              {pending === "remove" ? "Removing" : "Remove"}
+            </Button>
+          </div>
+        </div>
+      )}
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/agent/agent-command.tsx
+++ b/apps/dashboard/app/(dashboard)/agent/agent-command.tsx
@@ -70,7 +70,7 @@ export function AgentCommand({ aiReady, user }: AgentCommandProps) {
         className="px-0 pb-0"
         status={isPending || isRunning ? "submitted" : "ready"}
         disabled={!aiReady || isRunning}
-        placeholder={aiReady ? "Enter a URL..." : "Server AI key not configured"}
+        placeholder={aiReady ? "Enter a URL..." : "Add an OpenAI key on Account"}
         onStop={() => {}}
         onSend={({ content }) => {
           setError(null);
@@ -114,10 +114,10 @@ export function AgentCommand({ aiReady, user }: AgentCommandProps) {
             ? {
                 title: "Setup needed.",
                 description:
-                  "This deployment needs an AI key. For local CLI/SDK/API runs, see BYOK docs.",
+                  "Add an OpenAI key on Account to start a run. Capture still needs a Daytona key later.",
                 action: {
-                  label: "API docs",
-                  onClick: () => router.push("/api"),
+                  label: "Account",
+                  onClick: () => router.push("/account"),
                 },
               }
             : undefined

--- a/apps/dashboard/app/(dashboard)/agent/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agent/page.tsx
@@ -1,6 +1,9 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 
+import { api } from "@convex/_generated/api";
+import { getConvexClient } from "@/lib/convex-server";
+
 import { AgentCommand } from "./agent-command";
 
 export default async function AgentPage() {
@@ -10,7 +13,10 @@ export default async function AgentPage() {
     redirect("/sign-in");
   }
 
-  const aiReady = Boolean(process.env.OPENAI_API_KEY);
+  const keys = await getConvexClient().query(api.userCredentials.listForUser, {
+    userId: user.id,
+  });
+  const aiReady = keys.some((key) => key.provider === "openai");
 
   return (
     <AgentCommand

--- a/apps/dashboard/app/api/credentials/route.ts
+++ b/apps/dashboard/app/api/credentials/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+
+import { api } from "@convex/_generated/api";
+import { getConvexClient } from "@/lib/convex-server";
+import {
+  encryptCredential,
+  keySuffix,
+} from "@/lib/credential-crypto";
+
+export const runtime = "nodejs";
+
+const PROVIDERS = ["daytona", "openai"] as const;
+type Provider = (typeof PROVIDERS)[number];
+
+function isProvider(value: unknown): value is Provider {
+  return value === "daytona" || value === "openai";
+}
+
+function readProvider(body: unknown): Provider | null {
+  if (!body || typeof body !== "object") return null;
+  const provider = (body as { provider?: unknown }).provider;
+  return isProvider(provider) ? provider : null;
+}
+
+export async function POST(request: Request) {
+  const { user } = await withAuth({ ensureSignedIn: true });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const provider = readProvider(body);
+  if (!provider) {
+    return NextResponse.json(
+      { error: "Provider must be daytona or openai." },
+      { status: 400 },
+    );
+  }
+
+  const key = (body as { key?: unknown }).key;
+  if (typeof key !== "string" || !key.trim()) {
+    return NextResponse.json({ error: "Key is required." }, { status: 400 });
+  }
+
+  const trimmed = key.trim();
+
+  try {
+    const { ciphertext, iv } = await encryptCredential(trimmed);
+    const suffix = keySuffix(trimmed);
+    const convex = getConvexClient();
+    await convex.mutation(api.userCredentials.upsertEncrypted, {
+      userId: user.id,
+      provider,
+      ciphertext,
+      iv,
+      keySuffix: suffix,
+    });
+    return NextResponse.json({
+      ok: true,
+      provider,
+      keySuffix: suffix,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Could not save key.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const { user } = await withAuth({ ensureSignedIn: true });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const provider = readProvider(body);
+  if (!provider) {
+    return NextResponse.json(
+      { error: "Provider must be daytona or openai." },
+      { status: 400 },
+    );
+  }
+
+  const convex = getConvexClient();
+  const result = await convex.mutation(api.userCredentials.remove, {
+    userId: user.id,
+    provider,
+  });
+  return NextResponse.json(result);
+}

--- a/apps/dashboard/app/api/runs/[id]/_run-step.ts
+++ b/apps/dashboard/app/api/runs/[id]/_run-step.ts
@@ -15,6 +15,11 @@ import type { ScreenshotArtifact } from "@getdesign/tools/daytona";
 import type { DesignDoc, DesignTokens } from "@getdesign/types";
 
 import { getConvexClient } from "@/lib/convex-server";
+import {
+  requireDaytonaCredential,
+  requireOpenAiCredential,
+  resolveRunCredentials,
+} from "@/lib/run-credentials";
 import type { RunStep } from "@/lib/runs-store";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
@@ -148,17 +153,13 @@ async function runCaptureStep({
   artifacts,
 }: RunContext) {
   const crawl = await requireCrawl(artifacts);
-  if (!process.env.DAYTONA_API_KEY) {
-    throw new StepError(
-      "capture",
-      "No Daytona API key available; set DAYTONA_API_KEY before starting a visual run.",
-    );
-  }
+  const credentials = await resolveRunCredentials(userId);
+  const daytonaApiKey = requireDaytonaCredential(credentials);
 
   await beginStep(convex, runId, userId, "capture", "Capturing page");
   const captured = await runVisual(
     { url: crawl.sourceUrl },
-    { daytonaApiKey: process.env.DAYTONA_API_KEY },
+    { daytonaApiKey },
   );
   const visual = await storeVisual(convex, runId, userId, captured);
   const mode = visual.status === "captured" ? "visual" : "text_only";
@@ -220,6 +221,8 @@ async function runDescribeStep({
     return;
   }
 
+  const credentials = await resolveRunCredentials(userId);
+  const openaiApiKey = requireOpenAiCredential(credentials);
   await beginStep(convex, runId, userId, "describe", "Describing screenshots");
   const tiles = await loadTileArtifacts(convex, runId, userId, visual);
   const result = await runDescribe({
@@ -229,7 +232,7 @@ async function runDescribeStep({
     documentHeight: visual.documentHeight ?? visual.viewport.height,
     documentWidth: visual.documentWidth ?? visual.viewport.width,
     viewport: visual.viewport,
-    model: resolveModel({ apiKey: process.env.OPENAI_API_KEY }),
+    model: resolveModel({ apiKey: openaiApiKey }),
   });
   await saveText(convex, runId, userId, "description", result.description);
   const wordCount = result.description.split(/\s+/).filter(Boolean).length;
@@ -257,6 +260,8 @@ async function runSynthesizeStep({
   const description = typeof artifacts.description === "string"
     ? artifacts.description
     : "";
+  const credentials = await resolveRunCredentials(userId);
+  const openaiApiKey = requireOpenAiCredential(credentials);
   await beginStep(convex, runId, userId, "synthesize", "Synthesizing design doc");
   const tiles = visual?.status === "captured"
     ? await loadTileArtifacts(convex, runId, userId, visual)
@@ -268,7 +273,7 @@ async function runSynthesizeStep({
     tiles: tiles.length > 0 ? tiles : undefined,
     visualDescription: description.trim() || undefined,
     crawlNotes: crawl.notes,
-    model: resolveModel({ apiKey: process.env.OPENAI_API_KEY }),
+    model: resolveModel({ apiKey: openaiApiKey }),
   });
   await saveValue(convex, runId, userId, "doc", result.doc);
   await finishStep(

--- a/apps/dashboard/lib/credential-crypto.test.ts
+++ b/apps/dashboard/lib/credential-crypto.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  decryptCredential,
+  encryptCredential,
+  keySuffix,
+} from "./credential-crypto";
+
+const HEX_KEY = "ab".repeat(32);
+const BASE64_KEY = Buffer.alloc(32, 7).toString("base64");
+
+afterEach(() => {
+  delete process.env.GETDESIGN_CREDENTIALS_KEY;
+});
+
+describe("credential-crypto", () => {
+  test("encrypt/decrypt roundtrip with a hex master key", async () => {
+    process.env.GETDESIGN_CREDENTIALS_KEY = HEX_KEY;
+    const plaintext = "sk-test-secret-key";
+    const { ciphertext, iv } = await encryptCredential(plaintext);
+
+    expect(ciphertext).not.toContain("sk-test");
+    expect(ciphertext).not.toBe(plaintext);
+    expect(await decryptCredential(ciphertext, iv)).toBe(plaintext);
+  });
+
+  test("encrypt/decrypt roundtrip with a base64 master key", async () => {
+    process.env.GETDESIGN_CREDENTIALS_KEY = BASE64_KEY;
+    const { ciphertext, iv } = await encryptCredential("dtn_abc123");
+    expect(await decryptCredential(ciphertext, iv)).toBe("dtn_abc123");
+  });
+
+  test("same plaintext produces different ciphertext", async () => {
+    process.env.GETDESIGN_CREDENTIALS_KEY = HEX_KEY;
+    const first = await encryptCredential("sk-repeat");
+    const second = await encryptCredential("sk-repeat");
+    expect(first.ciphertext).not.toBe(second.ciphertext);
+    expect(first.iv).not.toBe(second.iv);
+  });
+
+  test("keySuffix is the last four characters of the trimmed key", () => {
+    expect(keySuffix("sk-abcdefgh")).toBe("efgh");
+    expect(keySuffix("  dtn_wxyz  ")).toBe("wxyz");
+  });
+
+  test("keySuffix rejects keys shorter than four characters", () => {
+    expect(() => keySuffix("abc")).toThrow(/too short/);
+  });
+
+  test("encrypt rejects a missing GETDESIGN_CREDENTIALS_KEY", async () => {
+    await expect(encryptCredential("sk-test")).rejects.toThrow(
+      /GETDESIGN_CREDENTIALS_KEY is not set/,
+    );
+  });
+
+  test("encrypt rejects invalid master key material", async () => {
+    process.env.GETDESIGN_CREDENTIALS_KEY = "too-short";
+    await expect(encryptCredential("sk-test")).rejects.toThrow(/32 bytes/);
+  });
+});

--- a/apps/dashboard/lib/credential-crypto.ts
+++ b/apps/dashboard/lib/credential-crypto.ts
@@ -1,0 +1,105 @@
+const KEY_ENV = "GETDESIGN_CREDENTIALS_KEY";
+const AES_KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+export class CredentialCryptoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialCryptoError";
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(AES_KEY_BYTES);
+  for (let i = 0; i < AES_KEY_BYTES; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array<ArrayBuffer>): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function base64ToBytes(value: string): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(Buffer.from(value, "base64"));
+}
+
+function parseKeyMaterial(value: string): Uint8Array<ArrayBuffer> {
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return hexToBytes(value);
+  }
+
+  const decoded = base64ToBytes(value);
+  if (decoded.byteLength === AES_KEY_BYTES) {
+    return decoded;
+  }
+
+  throw new CredentialCryptoError(
+    `${KEY_ENV} must be 32 bytes (64 hex characters or base64).`,
+  );
+}
+
+function getMasterKeyBytes(): Uint8Array<ArrayBuffer> {
+  const raw = process.env[KEY_ENV];
+  if (!raw || raw.trim() === "") {
+    throw new CredentialCryptoError(
+      `${KEY_ENV} is not set. Provide a 32-byte key as 64 hex characters or base64.`,
+    );
+  }
+  return parseKeyMaterial(raw.trim());
+}
+
+async function importAesKey(): Promise<CryptoKey> {
+  return await crypto.subtle.importKey(
+    "raw",
+    getMasterKeyBytes(),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export function keySuffix(rawKey: string): string {
+  const trimmed = rawKey.trim();
+  if (trimmed.length < 4) {
+    throw new CredentialCryptoError("API key is too short to store.");
+  }
+  return trimmed.slice(-4);
+}
+
+export async function encryptCredential(plaintext: string): Promise<{
+  ciphertext: string;
+  iv: string;
+}> {
+  const trimmed = plaintext.trim();
+  if (!trimmed) {
+    throw new CredentialCryptoError("API key cannot be empty.");
+  }
+
+  const key = await importAesKey();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(trimmed),
+  );
+
+  return {
+    ciphertext: bytesToBase64(new Uint8Array(encrypted)),
+    iv: bytesToBase64(new Uint8Array(iv)),
+  };
+}
+
+export async function decryptCredential(
+  ciphertext: string,
+  iv: string,
+): Promise<string> {
+  const key = await importAesKey();
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: base64ToBytes(iv) },
+    key,
+    base64ToBytes(ciphertext),
+  );
+  return new TextDecoder().decode(decrypted);
+}

--- a/apps/dashboard/lib/run-credentials.ts
+++ b/apps/dashboard/lib/run-credentials.ts
@@ -1,0 +1,61 @@
+import { api } from "@convex/_generated/api";
+
+import { getConvexClient } from "@/lib/convex-server";
+import { decryptCredential } from "@/lib/credential-crypto";
+
+export type RunCredentials = {
+  daytonaApiKey?: string;
+  openaiApiKey?: string;
+};
+
+export async function resolveRunCredentials(
+  userId: string,
+): Promise<RunCredentials> {
+  const convex = getConvexClient();
+  const [daytona, openai] = await Promise.all([
+    convex.query(api.userCredentials.getEncrypted, {
+      userId,
+      provider: "daytona",
+    }),
+    convex.query(api.userCredentials.getEncrypted, {
+      userId,
+      provider: "openai",
+    }),
+  ]);
+
+  const credentials: RunCredentials = {};
+
+  if (daytona) {
+    credentials.daytonaApiKey = await decryptCredential(
+      daytona.ciphertext,
+      daytona.iv,
+    );
+  }
+
+  if (openai) {
+    credentials.openaiApiKey = await decryptCredential(
+      openai.ciphertext,
+      openai.iv,
+    );
+  }
+
+  return credentials;
+}
+
+export function requireDaytonaCredential(credentials: RunCredentials): string {
+  if (!credentials.daytonaApiKey) {
+    throw new Error(
+      "No Daytona API key stored. Add one on Account before capture can run.",
+    );
+  }
+  return credentials.daytonaApiKey;
+}
+
+export function requireOpenAiCredential(credentials: RunCredentials): string {
+  if (!credentials.openaiApiKey) {
+    throw new Error(
+      "No OpenAI API key stored. Add one on Account before describe or synthesize can run.",
+    );
+  }
+  return credentials.openaiApiKey;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as designRunArtifacts from "../designRunArtifacts.js";
 import type * as designRuns from "../designRuns.js";
+import type * as userCredentials from "../userCredentials.js";
 import type * as waitlist from "../waitlist.js";
 
 import type {
@@ -21,6 +22,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   designRunArtifacts: typeof designRunArtifacts;
   designRuns: typeof designRuns;
+  userCredentials: typeof userCredentials;
   waitlist: typeof waitlist;
 }>;
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -119,4 +119,12 @@ export default defineSchema({
   })
     .index("by_run", ["runId"])
     .index("by_run_kind", ["runId", "kind"]),
+  userCredentials: defineTable({
+    userId: v.string(),
+    provider: v.union(v.literal("daytona"), v.literal("openai")),
+    ciphertext: v.string(),
+    iv: v.string(),
+    keySuffix: v.string(),
+    updatedAt: v.number(),
+  }).index("by_user_and_provider", ["userId", "provider"]),
 });

--- a/convex/userCredentials.ts
+++ b/convex/userCredentials.ts
@@ -1,0 +1,132 @@
+import { ConvexError, v } from "convex/values";
+
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+
+const providerSchema = v.union(v.literal("daytona"), v.literal("openai"));
+
+const metadataSchema = v.object({
+  provider: providerSchema,
+  keySuffix: v.string(),
+  updatedAt: v.number(),
+});
+
+type Provider = "daytona" | "openai";
+
+async function findOwnedCredential(
+  ctx: QueryCtx | MutationCtx,
+  userId: string,
+  provider: Provider,
+) {
+  const row = await ctx.db
+    .query("userCredentials")
+    .withIndex("by_user_and_provider", (q) =>
+      q.eq("userId", userId).eq("provider", provider),
+    )
+    .unique();
+
+  if (!row) return null;
+  if (row.userId !== userId) {
+    throw new ConvexError("Unauthorized");
+  }
+  return row;
+}
+
+export const upsertEncrypted = mutation({
+  args: {
+    userId: v.string(),
+    provider: providerSchema,
+    ciphertext: v.string(),
+    iv: v.string(),
+    keySuffix: v.string(),
+  },
+  returns: v.id("userCredentials"),
+  handler: async (ctx, args) => {
+    const existing = await findOwnedCredential(ctx, args.userId, args.provider);
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        ciphertext: args.ciphertext,
+        iv: args.iv,
+        keySuffix: args.keySuffix,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("userCredentials", {
+      userId: args.userId,
+      provider: args.provider,
+      ciphertext: args.ciphertext,
+      iv: args.iv,
+      keySuffix: args.keySuffix,
+      updatedAt: now,
+    });
+  },
+});
+
+export const remove = mutation({
+  args: {
+    userId: v.string(),
+    provider: providerSchema,
+  },
+  returns: v.object({ ok: v.boolean() }),
+  handler: async (ctx, args) => {
+    const existing = await findOwnedCredential(ctx, args.userId, args.provider);
+    if (!existing) return { ok: false };
+    await ctx.db.delete(existing._id);
+    return { ok: true };
+  },
+});
+
+export const listForUser = query({
+  args: {
+    userId: v.string(),
+  },
+  returns: v.array(metadataSchema),
+  handler: async (ctx, { userId }) => {
+    const rows = await ctx.db
+      .query("userCredentials")
+      .withIndex("by_user_and_provider", (q) => q.eq("userId", userId))
+      .collect();
+
+    return rows
+      .filter((row) => row.userId === userId)
+      .map((row) => ({
+        provider: row.provider,
+        keySuffix: row.keySuffix,
+        updatedAt: row.updatedAt,
+      }));
+  },
+});
+
+export const getEncrypted = query({
+  args: {
+    userId: v.string(),
+    provider: providerSchema,
+  },
+  returns: v.union(
+    v.object({
+      provider: providerSchema,
+      ciphertext: v.string(),
+      iv: v.string(),
+      keySuffix: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const row = await findOwnedCredential(ctx, args.userId, args.provider);
+    if (!row) return null;
+    return {
+      provider: row.provider,
+      ciphertext: row.ciphertext,
+      iv: row.iv,
+      keySuffix: row.keySuffix,
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- Account can save one Daytona key and one OpenAI key. Payload is AES-256-GCM ciphertext in Convex. UI only shows a masked suffix.
- Dashboard runs decrypt those keys on the server and no longer read `DAYTONA_API_KEY` / `OPENAI_API_KEY` from the host env.
- Agent page is ready when the signed-in user has a stored OpenAI key.

## Surface(s) affected
- [x] Convex (`convex/`)

Dashboard Account + run pipeline.

## Breaking changes?
- [x] Yes — migration notes:
  - Set `GETDESIGN_CREDENTIALS_KEY` (32-byte hex or base64: `openssl rand -hex 32`) in the dashboard env.
  - Run `npx convex dev` / deploy so the `userCredentials` table exists.
  - Existing server env keys are ignored for dashboard runs. Each user must paste keys on Account.

## Test plan
- [ ] `bun test apps/dashboard/lib/credential-crypto.test.ts`
- [ ] Save Daytona + OpenAI keys on Account, confirm suffix only
- [ ] Start a run and confirm capture/synthesize use the stored keys
- [ ] Remove a key and confirm the matching step fails with the Account copy

## Merge note
Merge this before `feat/v1-text-only-opt-in`. Both edit `_run-step.ts`.


Made with [Cursor](https://cursor.com)