### PR TITLE
feat(api): require WorkOS bearer auth and BYOK headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 
 ### Changed
 
+- **[api]** HTTP API now requires a WorkOS bearer token and request-scoped BYOK headers.
 - **[web]** Surfaces section heading `"Four surfaces, one agent."` → `"Five surfaces, one agent."` with revised subhead.
 - **[web]** Footer GitHub link now points at [github.com/MohtashamMurshid/getdesign](https://github.com/MohtashamMurshid/getdesign) instead of the `github.com` placeholder.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes that affect the public surfaces (HTTP API, `@getdesign/sdk`, `@getdesign
 ### Changed
 
 - **[api]** HTTP API now requires a WorkOS bearer token and request-scoped BYOK headers.
+- **[content]** `buildCurlExample` and `buildApiRequest` include the WorkOS bearer header and request-scoped Daytona/OpenAI keys.
 - **[web]** Surfaces section heading `"Four surfaces, one agent."` → `"Five surfaces, one agent."` with revised subhead.
 - **[web]** Footer GitHub link now points at [github.com/MohtashamMurshid/getdesign](https://github.com/MohtashamMurshid/getdesign) instead of the `github.com` placeholder.
 

--- a/apps/api/CONTEXT.md
+++ b/apps/api/CONTEXT.md
@@ -9,3 +9,5 @@ Terms and naming for the HTTP API workspace (`apps/api`). Expand as the domain s
 - **Request-scoped credentials** — Daytona and OpenAI keys sent only for the current request via headers. The API must forward them to the agent and must never log or echo them.
 - **Text-only retry** — A degraded run requested with `x-getdesign-mode: text_only` after visual capture fails or the user explicitly accepts non-visual output.
 - **Public progress event** — Sanitized progress data sent to SDK/CLI clients. It omits screenshot tile image data, raw crawl payloads, and credentials.
+- **WorkOS bearer auth** — Design endpoints accept `Authorization: Bearer <WorkOS AuthKit access token>`. There is no getdesign API key in v1.
+- **credentials_missing** — `409` when the caller is authenticated but required request-scoped Daytona and/or OpenAI keys are absent. Distinct from `capture_failed`.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -11,12 +11,15 @@ GET /v1/design/stream?url=<absolute-url>
 
 `/v1/design` returns either `text/markdown; charset=utf-8` or JSON when `format=json`.
 `/v1/design/stream` returns Server-Sent Events: `progress`, then `result` or `error`.
-Request-scoped BYOK credentials are accepted via headers:
+Every design route requires `Authorization: Bearer <WorkOS access token>`.
+Request-scoped BYOK credentials are required via headers unless noted:
 
-- `x-daytona-api-key`
+- `x-daytona-api-key` (optional when `x-getdesign-mode: text_only`)
 - `x-openai-api-key`
 - `x-getdesign-mode: text_only` to accept text-only fallback
 - `x-getdesign-site-name` to override site naming
+
+`GET /health` is unauthenticated and returns `{ "ok": true }`.
 
 ## Responses
 
@@ -24,7 +27,9 @@ Request-scoped BYOK credentials are accepted via headers:
 - `200 application/json` — structured result for SDK clients.
 - `200 text/event-stream` — progress stream for SDK/CLI clients.
 - `400 application/json` — `{ "error": string }` when `url` is missing or not a valid absolute URL.
-- `409 application/json` — capture failed; retry with `x-getdesign-mode: text_only` if the user accepts degraded output.
+- `401 application/json` — `{ "error": "unauthorized" }` when the WorkOS bearer token is missing or invalid. Includes `WWW-Authenticate: Bearer`.
+- `409 application/json` — `{ "error": "credentials_missing", "code": "credentials_missing" }` when authenticated but required BYOK headers are absent.
+- `409 application/json` — capture failed (`code: capture_failed`); retry with `x-getdesign-mode: text_only` if the user accepts degraded output.
 - `500 application/json` — `{ "error": "internal" }` when the agent run fails. Stack traces are logged, never returned.
 
 ## Local development
@@ -32,8 +37,14 @@ Request-scoped BYOK credentials are accepted via headers:
 ```bash
 bun install                    # from repo root
 bun run --cwd apps/api dev     # boots Bun.serve on :3001
-curl 'http://localhost:3001/?url=https://example.com'
-curl 'http://localhost:3001/v1/design?url=https://example.com&format=json'
+curl 'http://localhost:3001/?url=https://example.com' \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY"
+curl 'http://localhost:3001/v1/design?url=https://example.com&format=json' \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY"
 ```
 
 `dev` uses Bun with `--hot`. The dev server shares the exact Hono app used in production (`src/app.ts`); only the transport differs.
@@ -54,6 +65,7 @@ Consumed by `@getdesign/agent` at request time; set them on the Vercel project w
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
+| `WORKOS_CLIENT_ID` | yes | Used to fetch WorkOS JWKS and verify AuthKit access tokens. Unset means every design request is `401`. |
 | `AI_GATEWAY_API_KEY` | yes | Resolved by `@getdesign/agent`'s `resolveModel()` to talk to the Vercel AI Gateway. `OPENAI_API_KEY` also accepted as a fallback. |
 | `DAYTONA_API_KEY` | yes | Used by the visual sub-agent to spawn Daytona sandboxes for screenshots. |
 | `GETDESIGN_MODEL` | no | Override the default OpenAI model id. |
@@ -82,7 +94,10 @@ apps/api/
 ├── api/
 │   └── index.ts          # Vercel function entry -> app.fetch
 ├── src/
-│   ├── app.ts            # Hono factory (injectable runDesign)
+│   ├── app.ts            # Hono factory (injectable runDesign + verifyAccessToken)
+│   ├── auth.ts           # WorkOS JWT / JWKS verifier
+│   ├── middleware/
+│   │   └── requireAccessToken.ts
 │   ├── dev.ts            # Bun.serve wrapper for local dev
 │   └── handlers/
 │       └── getDesign.ts  # GET / handler + Zod url validation

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@getdesign/agent": "workspace:*",
     "@getdesign/types": "workspace:*",
     "hono": "^4.6.14",
+    "jose": "^6.2.10",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,21 +1,35 @@
 import { Hono } from "hono";
 
+import {
+  verifyWorkosAccessToken,
+  type VerifyAccessTokenFn,
+} from "./auth";
 import type { RunDesignFn } from "./handlers/getDesign";
 import {
   createGetDesignHandler,
   createStreamDesignHandler,
 } from "./handlers/getDesign";
+import { requireAccessToken } from "./middleware/requireAccessToken";
+
+export type { VerifyAccessTokenFn };
 
 export type CreateAppOptions = {
   runDesign: RunDesignFn;
+  verifyAccessToken?: VerifyAccessTokenFn;
 };
 
-export function createApp({ runDesign }: CreateAppOptions): Hono {
+export function createApp({
+  runDesign,
+  verifyAccessToken = verifyWorkosAccessToken,
+}: CreateAppOptions): Hono {
   const app = new Hono();
+  const requireAuth = requireAccessToken(verifyAccessToken);
 
-  app.get("/", createGetDesignHandler(runDesign));
-  app.get("/v1/design", createGetDesignHandler(runDesign));
-  app.get("/v1/design/stream", createStreamDesignHandler(runDesign));
+  app.get("/health", (c) => c.json({ ok: true }));
+
+  app.get("/", requireAuth, createGetDesignHandler(runDesign));
+  app.get("/v1/design", requireAuth, createGetDesignHandler(runDesign));
+  app.get("/v1/design/stream", requireAuth, createStreamDesignHandler(runDesign));
 
   return app;
 }

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,0 +1,49 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const WORKOS_ISSUER = "https://api.workos.com";
+
+export type AccessTokenIdentity = {
+  userId: string;
+};
+
+export type VerifyAccessTokenFn = (
+  token: string,
+) => Promise<AccessTokenIdentity>;
+
+type RemoteJwkSet = ReturnType<typeof createRemoteJWKSet>;
+
+let cachedClientId: string | undefined;
+let cachedJwks: RemoteJwkSet | undefined;
+
+function workosJwks(clientId: string): RemoteJwkSet {
+  if (cachedJwks && cachedClientId === clientId) {
+    return cachedJwks;
+  }
+  cachedClientId = clientId;
+  cachedJwks = createRemoteJWKSet(
+    new URL(`https://api.workos.com/sso/jwks/${clientId}`),
+  );
+  return cachedJwks;
+}
+
+/**
+ * Production verifier for WorkOS AuthKit access tokens.
+ * Fail closed when WORKOS_CLIENT_ID is unset.
+ */
+export const verifyWorkosAccessToken: VerifyAccessTokenFn = async (token) => {
+  const clientId = process.env.WORKOS_CLIENT_ID?.trim();
+  if (!clientId) {
+    throw new Error("WORKOS_CLIENT_ID is unset");
+  }
+
+  const { payload } = await jwtVerify(token, workosJwks(clientId), {
+    issuer: WORKOS_ISSUER,
+  });
+
+  const userId = payload.sub;
+  if (!userId) {
+    throw new Error("Access token is missing sub");
+  }
+
+  return { userId };
+};

--- a/apps/api/src/handlers/getDesign.ts
+++ b/apps/api/src/handlers/getDesign.ts
@@ -41,6 +41,46 @@ function parseSiteName(c: Context): string | undefined {
   return c.req.query("siteName") ?? c.req.header(SITE_NAME_HEADER) ?? undefined;
 }
 
+function headerValue(c: Context, name: string): string {
+  return (c.req.header(name) ?? "").trim();
+}
+
+function credentialsMissingReason(c: Context): string | null {
+  const textOnly = parseVisualRequirement(c) === "text_only_fallback";
+  const daytona = headerValue(c, DAYTONA_HEADER);
+  const openai = headerValue(c, OPENAI_HEADER);
+
+  if (textOnly) {
+    if (!openai) {
+      return "Missing x-openai-api-key request-scoped credential";
+    }
+    return null;
+  }
+
+  const missing: string[] = [];
+  if (!daytona) missing.push("x-daytona-api-key");
+  if (!openai) missing.push("x-openai-api-key");
+  const [firstMissing] = missing;
+  if (!firstMissing) return null;
+  if (missing.length === 2) {
+    return "Missing x-daytona-api-key and x-openai-api-key request-scoped credentials";
+  }
+  return `Missing ${firstMissing} request-scoped credential`;
+}
+
+function credentialsMissingResponse(c: Context) {
+  const reason = credentialsMissingReason(c);
+  if (!reason) return null;
+  return c.json(
+    {
+      error: "credentials_missing",
+      code: "credentials_missing",
+      reason,
+    },
+    409,
+  );
+}
+
 function parseFormat(c: Context): ResponseFormat {
   const format = (c.req.query("format") ?? "").trim().toLowerCase();
   if (format === "json") return "json";
@@ -131,6 +171,9 @@ export function createGetDesignHandler(runDesign: RunDesignFn) {
       return c.json({ error: message }, 400);
     }
 
+    const blocked = credentialsMissingResponse(c);
+    if (blocked) return blocked;
+
     try {
       const result = await runDesign(parsed.data, {
         visualRequirement: parseVisualRequirement(c),
@@ -183,6 +226,9 @@ export function createStreamDesignHandler(runDesign: RunDesignFn) {
         parsed.error.issues[0]?.message ?? "Invalid `url` query parameter";
       return c.json({ error: message }, 400);
     }
+
+    const blocked = credentialsMissingResponse(c);
+    if (blocked) return blocked;
 
     return streamSSE(c, async (stream) => {
       try {

--- a/apps/api/src/middleware/requireAccessToken.ts
+++ b/apps/api/src/middleware/requireAccessToken.ts
@@ -1,0 +1,37 @@
+import type { Context, MiddlewareHandler } from "hono";
+
+import type { VerifyAccessTokenFn } from "../auth";
+
+function parseBearerToken(header: string | undefined): string | null {
+  if (!header) return null;
+  const match = /^Bearer[ \t]+(\S+)$/i.exec(header.trim());
+  return match?.[1] ?? null;
+}
+
+function unauthorized(c: Context) {
+  return c.json({ error: "unauthorized" }, 401, {
+    "WWW-Authenticate": "Bearer",
+  });
+}
+
+export function requireAccessToken(
+  verifyAccessToken: VerifyAccessTokenFn,
+): MiddlewareHandler {
+  return async (c, next) => {
+    const token = parseBearerToken(c.req.header("authorization"));
+    if (!token) {
+      return unauthorized(c);
+    }
+
+    try {
+      const identity = await verifyAccessToken(token);
+      if (!identity.userId) {
+        return unauthorized(c);
+      }
+    } catch {
+      return unauthorized(c);
+    }
+
+    await next();
+  };
+}

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import { RunDesignError, type RunDesignResult } from "@getdesign/agent";
 
 import { createApp } from "../src/app";
+import type { RunDesignFn } from "../src/handlers/getDesign";
 
 function stubResult(markdown: string): RunDesignResult {
   return {
@@ -18,14 +19,159 @@ function stubResult(markdown: string): RunDesignResult {
   };
 }
 
-test("GET / without url returns 400 JSON", async () => {
+const AUTH = { Authorization: "Bearer test-token" } as const;
+const BYOK = {
+  "x-daytona-api-key": "dtn_test",
+  "x-openai-api-key": "sk_test",
+} as const;
+
+function authedApp(runDesign: RunDesignFn) {
+  return createApp({
+    runDesign,
+    verifyAccessToken: async () => ({ userId: "user_test" }),
+  });
+}
+
+function request(path: string, headers?: Record<string, string>) {
+  return new Request(`http://localhost${path}`, { headers });
+}
+
+test("GET /health is unauthenticated", async () => {
   const app = createApp({
     runDesign: async () => {
       throw new Error("should not run");
     },
   });
 
-  const res = await app.fetch(new Request("http://localhost/"));
+  const res = await app.fetch(request("/health"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+});
+
+test("GET / without Authorization returns 401 and does not run", async () => {
+  let called = false;
+  const app = authedApp(async () => {
+    called = true;
+    return stubResult("# hi");
+  });
+
+  const res = await app.fetch(request("/?url=https://example.com"));
+  expect(res.status).toBe(401);
+  expect(res.headers.get("www-authenticate")).toBe("Bearer");
+  const body = (await res.json()) as { error: string };
+  expect(body.error).toBe("unauthorized");
+  expect(called).toBe(false);
+});
+
+test("GET / without injected verifier fails closed when WORKOS_CLIENT_ID is unset", async () => {
+  const previous = process.env.WORKOS_CLIENT_ID;
+  delete process.env.WORKOS_CLIENT_ID;
+  let called = false;
+  try {
+    const app = createApp({
+      runDesign: async () => {
+        called = true;
+        return stubResult("# hi");
+      },
+    });
+    const res = await app.fetch(
+      request("/?url=https://example.com", { ...AUTH, ...BYOK }),
+    );
+    expect(res.status).toBe(401);
+    expect(called).toBe(false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.WORKOS_CLIENT_ID;
+    } else {
+      process.env.WORKOS_CLIENT_ID = previous;
+    }
+  }
+});
+
+test("GET / when verifyAccessToken rejects returns 401", async () => {
+  let called = false;
+  const app = createApp({
+    runDesign: async () => {
+      called = true;
+      return stubResult("# hi");
+    },
+    verifyAccessToken: async () => {
+      throw new Error("invalid token");
+    },
+  });
+
+  const res = await app.fetch(
+    request("/?url=https://example.com", { ...AUTH, ...BYOK }),
+  );
+  expect(res.status).toBe(401);
+  expect(res.headers.get("www-authenticate")).toBe("Bearer");
+  const body = (await res.json()) as { error: string };
+  expect(body.error).toBe("unauthorized");
+  expect(called).toBe(false);
+});
+
+test("GET / with auth but missing BYOK headers returns 409 credentials_missing", async () => {
+  let called = false;
+  const app = authedApp(async () => {
+    called = true;
+    return stubResult("# hi");
+  });
+
+  const res = await app.fetch(request("/?url=https://example.com", { ...AUTH }));
+  expect(res.status).toBe(409);
+  const body = (await res.json()) as {
+    error: string;
+    code: string;
+    reason: string;
+  };
+  expect(body.error).toBe("credentials_missing");
+  expect(body.code).toBe("credentials_missing");
+  expect(body.reason.length).toBeGreaterThan(0);
+  expect(called).toBe(false);
+});
+
+test("GET /v1/design/stream without Authorization returns 401", async () => {
+  let called = false;
+  const app = authedApp(async () => {
+    called = true;
+    return stubResult("# hi");
+  });
+
+  const res = await app.fetch(
+    request("/v1/design/stream?url=https://example.com"),
+  );
+  expect(res.status).toBe(401);
+  expect((await res.json() as { error: string }).error).toBe("unauthorized");
+  expect(called).toBe(false);
+});
+
+test("GET / text_only mode without Daytona but with OpenAI reaches runDesign", async () => {
+  let called = false;
+  const app = authedApp(async () => {
+    called = true;
+    return {
+      ...stubResult("# text only"),
+      mode: "text_only",
+    } satisfies RunDesignResult;
+  });
+
+  const res = await app.fetch(
+    request("/?url=https://example.com", {
+      ...AUTH,
+      "x-getdesign-mode": "text_only",
+      "x-openai-api-key": "sk_test",
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(called).toBe(true);
+});
+
+test("GET / without url returns 400 JSON", async () => {
+  const app = authedApp(async () => {
+    throw new Error("should not run");
+  });
+
+  const res = await app.fetch(request("/", { ...AUTH }));
   expect(res.status).toBe(400);
   expect(res.headers.get("content-type") ?? "").toContain("application/json");
   const body = (await res.json()) as { error: string };
@@ -33,15 +179,11 @@ test("GET / without url returns 400 JSON", async () => {
 });
 
 test("GET /?url=notaurl returns 400 JSON", async () => {
-  const app = createApp({
-    runDesign: async () => {
-      throw new Error("should not run");
-    },
+  const app = authedApp(async () => {
+    throw new Error("should not run");
   });
 
-  const res = await app.fetch(
-    new Request("http://localhost/?url=notaurl"),
-  );
+  const res = await app.fetch(request("/?url=notaurl", { ...AUTH }));
   expect(res.status).toBe(400);
   const body = (await res.json()) as { error: string };
   expect(body.error.length).toBeGreaterThan(0);
@@ -50,15 +192,13 @@ test("GET /?url=notaurl returns 400 JSON", async () => {
 test("GET /?url=https://example.com returns 200 markdown from stub", async () => {
   const markdown = "# hi";
   let calledWith: string | undefined;
-  const app = createApp({
-    runDesign: async (url) => {
-      calledWith = url;
-      return stubResult(markdown);
-    },
+  const app = authedApp(async (url) => {
+    calledWith = url;
+    return stubResult(markdown);
   });
 
   const res = await app.fetch(
-    new Request("http://localhost/?url=https://example.com"),
+    request("/?url=https://example.com", { ...AUTH, ...BYOK }),
   );
   expect(res.status).toBe(200);
   expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
@@ -68,12 +208,13 @@ test("GET /?url=https://example.com returns 200 markdown from stub", async () =>
 });
 
 test("GET /v1/design?format=json returns structured result", async () => {
-  const app = createApp({
-    runDesign: async () => stubResult("# hi"),
-  });
+  const app = authedApp(async () => stubResult("# hi"));
 
   const res = await app.fetch(
-    new Request("http://localhost/v1/design?url=https://example.com&format=json"),
+    request("/v1/design?url=https://example.com&format=json", {
+      ...AUTH,
+      ...BYOK,
+    }),
   );
   expect(res.status).toBe(200);
   expect(res.headers.get("cache-control")).toBe("no-store");
@@ -84,15 +225,16 @@ test("GET /v1/design?format=json returns structured result", async () => {
 });
 
 test("GET /v1/design/stream returns progress and result events", async () => {
-  const app = createApp({
-    runDesign: async (_url, options) => {
-      await options?.onPhase?.({ phase: "crawl", status: "start" });
-      return stubResult("# streamed");
-    },
+  const app = authedApp(async (_url, options) => {
+    await options?.onPhase?.({ phase: "crawl", status: "start" });
+    return stubResult("# streamed");
   });
 
   const res = await app.fetch(
-    new Request("http://localhost/v1/design/stream?url=https://example.com"),
+    request("/v1/design/stream?url=https://example.com", {
+      ...AUTH,
+      ...BYOK,
+    }),
   );
   expect(res.status).toBe(200);
   const text = await res.text();
@@ -103,18 +245,16 @@ test("GET /v1/design/stream returns progress and result events", async () => {
 });
 
 test("GET / returns 409 when capture fails", async () => {
-  const app = createApp({
-    runDesign: async () => {
-      throw new RunDesignError({
-        status: "failed",
-        reason: "Chromium did not become ready",
-        attempts: 3,
-      });
-    },
+  const app = authedApp(async () => {
+    throw new RunDesignError({
+      status: "failed",
+      reason: "Chromium did not become ready",
+      attempts: 3,
+    });
   });
 
   const res = await app.fetch(
-    new Request("http://localhost/?url=https://example.com"),
+    request("/?url=https://example.com", { ...AUTH, ...BYOK }),
   );
   expect(res.status).toBe(409);
   const body = (await res.json()) as {
@@ -127,23 +267,20 @@ test("GET / returns 409 when capture fails", async () => {
 
 test("GET / forwards x-getdesign-mode and credential headers to runDesign", async () => {
   let received: { url: string; options?: unknown } | undefined;
-  const app = createApp({
-    runDesign: async (url, options) => {
-      received = { url, options };
-      return {
-        ...stubResult("# text only"),
-        mode: "text_only",
-      } satisfies RunDesignResult;
-    },
+  const app = authedApp(async (url, options) => {
+    received = { url, options };
+    return {
+      ...stubResult("# text only"),
+      mode: "text_only",
+    } satisfies RunDesignResult;
   });
 
   const res = await app.fetch(
-    new Request("http://localhost/?url=https://example.com", {
-      headers: {
-        "x-getdesign-mode": "text_only",
-        "x-daytona-api-key": "dtn_test",
-        "x-openai-api-key": "sk_test",
-      },
+    request("/?url=https://example.com", {
+      ...AUTH,
+      "x-getdesign-mode": "text_only",
+      "x-daytona-api-key": "dtn_test",
+      "x-openai-api-key": "sk_test",
     }),
   );
   expect(res.status).toBe(200);
@@ -158,17 +295,15 @@ test("GET / forwards x-getdesign-mode and credential headers to runDesign", asyn
 });
 
 test("GET / returns 500 JSON when runDesign throws", async () => {
-  const app = createApp({
-    runDesign: async () => {
-      throw new Error("boom");
-    },
+  const app = authedApp(async () => {
+    throw new Error("boom");
   });
 
   const originalError = console.error;
   console.error = () => {};
   try {
     const res = await app.fetch(
-      new Request("http://localhost/?url=https://example.com"),
+      request("/?url=https://example.com", { ...AUTH, ...BYOK }),
     );
     expect(res.status).toBe(500);
     const body = (await res.json()) as { error: string };

--- a/apps/dashboard/app/(dashboard)/api/page.tsx
+++ b/apps/dashboard/app/(dashboard)/api/page.tsx
@@ -81,17 +81,21 @@ export default function ApiPage() {
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-medium">Authentication</h2>
         <ul className="space-y-2 text-sm text-muted-foreground">
-          <li>No getdesign API key in v1 — public calls need no Bearer token.</li>
           <li>
-            Optional BYOK headers for full capture:{" "}
+            Send{" "}
+            <code className="font-mono text-xs text-foreground">
+              Authorization: Bearer &lt;WorkOS access token&gt;
+            </code>{" "}
+            plus{" "}
             <code className="font-mono text-xs text-foreground">
               x-daytona-api-key
-            </code>
-            ,{" "}
+            </code>{" "}
+            and{" "}
             <code className="font-mono text-xs text-foreground">
               x-openai-api-key
             </code>
-            . Never put secrets in the query string.
+            . There is no getdesign API key in v1. Never put secrets in the query
+            string.
           </li>
           <li>
             Optional:{" "}

--- a/apps/dashboard/components/developer/credential-callout.tsx
+++ b/apps/dashboard/components/developer/credential-callout.tsx
@@ -14,8 +14,8 @@ const COPY: Record<
   { title: string; body: string }
 > = {
   api: {
-    title: "No getdesign API key yet",
-    body: "Public v1 calls need no getdesign auth. For full visual capture with your own infra, pass Daytona and OpenAI keys in request headers — never in query strings.",
+    title: "No getdesign API key",
+    body: "Send Authorization: Bearer <WorkOS access token> plus x-daytona-api-key and x-openai-api-key. Never put secrets in the query string.",
   },
   cli: {
     title: "Bring your own keys",

--- a/apps/dashboard/components/developer/previews/api-preview.tsx
+++ b/apps/dashboard/components/developer/previews/api-preview.tsx
@@ -1,4 +1,4 @@
-import type { DemoSite } from "@getdesign/content";
+import { buildApiRequest, type DemoSite } from "@getdesign/content";
 
 type ApiPreviewProps = {
   site: DemoSite;
@@ -14,12 +14,7 @@ export function ApiPreview({ site, visibleSteps, done }: ApiPreviewProps) {
           request
         </div>
         <pre className="m-0 mt-2 whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-[12.5px] leading-relaxed text-foreground">
-          <span className="tok-key">GET</span>{" "}
-          <span className="tok-str">
-            https://api.getdesign.app/?url={site.url}
-          </span>
-          {"\n"}
-          <span className="tok-com">Accept: text/markdown</span>
+          {buildApiRequest(site.url)}
         </pre>
       </div>
 

--- a/apps/docs/src/content/docs/guides/call-the-api.mdx
+++ b/apps/docs/src/content/docs/guides/call-the-api.mdx
@@ -7,6 +7,9 @@ description: One-command usage of the getdesign HTTP API.
 
 ```bash
 curl "https://api.getdesign.app/?url=https://stripe.com" \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY" \
   -H "Accept: text/markdown" \
   -o stripe.design.md
 ```
@@ -14,7 +17,11 @@ curl "https://api.getdesign.app/?url=https://stripe.com" \
 ## Pipe it straight into a file
 
 ```bash
-curl -sS "https://api.getdesign.app/?url=https://linear.app" > linear.design.md
+curl -sS "https://api.getdesign.app/?url=https://linear.app" \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY" \
+  > linear.design.md
 ```
 
 ## Use with jq for palette only
@@ -23,6 +30,9 @@ The response is Markdown, not JSON, so `jq` does not apply directly. For palette
 
 ```bash
 curl -sS "https://api.getdesign.app/?url=https://stripe.com" \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY" \
   | awk '/^## 2\./,/^## 3\./' > stripe.palette.md
 ```
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -33,7 +33,7 @@ getdesign ships five surfaces that share one agent core. Only the transport chan
   />
   <LinkCard
     title="API"
-    description="GET /?url=... returns text/markdown. No auth in v1."
+    description="GET /?url=... returns text/markdown. WorkOS bearer token plus BYOK headers."
     href="/surfaces/api/"
   />
   <LinkCard

--- a/apps/docs/src/content/docs/quickstart.mdx
+++ b/apps/docs/src/content/docs/quickstart.mdx
@@ -14,10 +14,13 @@ Pick a surface and paste a URL. Every surface returns the same `design.md`.
   <TabItem label="API">
     ```bash
     curl "https://api.getdesign.app/?url=https://stripe.com" \
+      -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+      -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+      -H "x-openai-api-key: $OPENAI_API_KEY" \
       -H "Accept: text/markdown" \
       -o stripe.design.md
     ```
-    No auth is required in v1. Rate limits apply.
+    Send a WorkOS access token plus the BYOK headers. Rate limits apply.
   </TabItem>
   <TabItem label="CLI">
     ```bash

--- a/apps/docs/src/content/docs/resources/faq.mdx
+++ b/apps/docs/src/content/docs/resources/faq.mdx
@@ -21,7 +21,7 @@ The output describes publicly visible design choices of the target site. Respect
 
 ## Is there authentication?
 
-Not in v1. Rate limits apply.
+The HTTP API expects `Authorization: Bearer <WorkOS access token>`. There is no getdesign API key in v1. Visual runs also need `x-daytona-api-key` and `x-openai-api-key`.
 
 ## Is there a free tier?
 

--- a/apps/docs/src/content/docs/surfaces/api.mdx
+++ b/apps/docs/src/content/docs/surfaces/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API
-description: HTTP endpoint that turns a URL into text/markdown. No auth in v1.
+description: HTTP endpoint that turns a URL into text/markdown.
 ---
 
 The API lives at `api.getdesign.app`. One endpoint, one response type: `text/markdown`.
@@ -9,6 +9,9 @@ The API lives at `api.getdesign.app`. One endpoint, one response type: `text/mar
 
 ```http
 GET https://api.getdesign.app/?url=<target>
+Authorization: Bearer <WorkOS access token>
+x-daytona-api-key: <key>
+x-openai-api-key: <key>
 Accept: text/markdown
 ```
 
@@ -16,6 +19,9 @@ Accept: text/markdown
 
 ```bash
 curl "https://api.getdesign.app/?url=https://stripe.com" \
+  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \
+  -H "x-daytona-api-key: $DAYTONA_API_KEY" \
+  -H "x-openai-api-key: $OPENAI_API_KEY" \
   -H "Accept: text/markdown" \
   -o stripe.design.md
 ```
@@ -31,10 +37,14 @@ curl "https://api.getdesign.app/?url=https://stripe.com" \
 
 - `200 OK` with `Content-Type: text/markdown; charset=utf-8` and the full `design.md` body.
 - `400 Bad Request` if `url` is missing or invalid.
+- `401 Unauthorized` if the WorkOS bearer token is missing or invalid.
+- `409` with `code: credentials_missing` if Daytona and/or OpenAI request-scoped keys are absent.
+- `409` with `code: capture_failed` if visual capture cannot finish. Retry with `x-getdesign-mode: text_only` if you accept degraded output.
 - `429 Too Many Requests` if you exceed the public rate limit.
 
 ## Notes
 
-- No authentication in v1.
+- Send `Authorization: Bearer <WorkOS access token>`. There is no getdesign API key in v1.
+- Visual runs need `x-daytona-api-key` and `x-openai-api-key`. Text-only still needs the OpenAI key. Daytona is optional in that mode.
 - The extractor renders the target in a real browser. First-run latency can be a few seconds.
 - Respect the target site's terms when using the output.

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@getdesign/agent": "workspace:*",
         "@getdesign/types": "workspace:*",
         "hono": "^4.6.14",
+        "jose": "^6.2.10",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -2875,7 +2876,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
@@ -4416,6 +4417,8 @@
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@workos-inc/authkit-nextjs/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/packages/content/src/index.test.ts
+++ b/packages/content/src/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEMO_SITES,
   DOCS_BASE_URL,
+  buildApiRequest,
   buildCliCommand,
   buildCurlExample,
   buildSdkInstall,
@@ -25,7 +26,14 @@ describe("@getdesign/content", () => {
   });
 
   test("snippet builders", () => {
-    expect(buildCurlExample("stripe.com")).toContain("api.getdesign.app");
+    const curl = buildCurlExample("stripe.com");
+    expect(curl).toContain("api.getdesign.app");
+    expect(curl).toContain("Authorization: Bearer $WORKOS_ACCESS_TOKEN");
+    expect(curl).toContain("x-daytona-api-key: $DAYTONA_API_KEY");
+    expect(curl).toContain("x-openai-api-key: $OPENAI_API_KEY");
+    expect(buildApiRequest("stripe.com")).toContain(
+      "Authorization: Bearer $WORKOS_ACCESS_TOKEN",
+    );
     expect(buildCliCommand("cursor.com")).toContain("bunx @getdesign/cli");
     expect(buildSdkInstall()).toBe("bun add @getdesign/sdk");
   });

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -121,14 +121,27 @@ export function exampleUrl(siteUrl: string): string {
 
 export function buildApiRequest(siteUrl: string): string {
   const url = exampleUrl(siteUrl);
-  return `GET ${API_BASE_URL}/?url=${url}\nAccept: text/markdown`;
+  return [
+    `GET ${API_BASE_URL}/?url=${url}`,
+    "Authorization: Bearer $WORKOS_ACCESS_TOKEN",
+    "x-daytona-api-key: $DAYTONA_API_KEY",
+    "x-openai-api-key: $OPENAI_API_KEY",
+    "Accept: text/markdown",
+  ].join("\n");
 }
 
 export function buildCurlExample(siteUrl: string): string {
   const url = exampleUrl(siteUrl);
   const host = siteUrl.replace(/^https?:\/\//, "").split("/")[0] ?? "site";
   const slug = host.replace(/\./g, "-");
-  return `curl "${API_BASE_URL}/?url=${url}" \\\n  -H "Accept: text/markdown" \\\n  -o ${slug}.design.md`;
+  return [
+    `curl "${API_BASE_URL}/?url=${url}" \\`,
+    `  -H "Authorization: Bearer $WORKOS_ACCESS_TOKEN" \\`,
+    `  -H "x-daytona-api-key: $DAYTONA_API_KEY" \\`,
+    `  -H "x-openai-api-key: $OPENAI_API_KEY" \\`,
+    `  -H "Accept: text/markdown" \\`,
+    `  -o ${slug}.design.md`,
+  ].join("\n");
 }
 
 export function buildCliCommand(siteUrl: string): string {


### PR DESCRIPTION
## Summary
- Design routes (`GET /`, `/v1/design`, `/v1/design/stream`) return 401 without a valid WorkOS bearer token.
- Authenticated calls without request-scoped Daytona/OpenAI keys return 409 `credentials_missing` and never start `runDesign`. Text-only still needs OpenAI; Daytona is optional in that mode.
- Shared `buildCurlExample` / `buildApiRequest` now include the WorkOS bearer header and BYOK keys, so the dashboard copy-paste command matches the API.

## Surface(s) affected
- [x] HTTP API (`apps/api`)
- [x] Repo tooling / docs

Dashboard API page + credential callout. `@getdesign/content` snippet builders.

## Breaking changes?
- [x] Yes — migration notes:
  - Set `WORKOS_CLIENT_ID` on the API deployment.
  - Callers must send `Authorization: Bearer <WorkOS access token>` plus `x-daytona-api-key` and `x-openai-api-key`.

## Test plan
- [ ] `bun test --cwd apps/api` (15 tests)
- [ ] `bun test packages/content/src/index.test.ts`
- [ ] `bun run --cwd apps/api typecheck`
- [ ] Unsigned `GET /v1/design?url=...` returns 401
- [ ] Signed request without BYOK headers returns 409
- [ ] Dashboard API page curl includes Authorization and both key headers